### PR TITLE
feat/#5 : DateEntity, Memo 엔티티 구현, 롬복 추가

### DIFF
--- a/mylog/build.gradle
+++ b/mylog/build.gradle
@@ -35,6 +35,14 @@ dependencies {
 	testImplementation 'org.springframework.amqp:spring-rabbit-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
+
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// 테스트 코드에서도 롬복 사용
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+
 }
 
 tasks.named('test') {

--- a/mylog/src/main/java/mylog_backend/mylog/common/domain/DateEntity.java
+++ b/mylog/src/main/java/mylog_backend/mylog/common/domain/DateEntity.java
@@ -1,0 +1,28 @@
+package mylog_backend.mylog.common.domain;
+
+// 생성일자, 수정일자를 선언한 엔티티
+// 메모, 일기 엔티티는 이 엔티티를 상속받아서 사용한다.
+// Spring Auditing을 사용하여 자동으로 생성일자와 수정일자를 업데이트한다.
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+
+@EntityListeners(value = {AuditingEntityListener.class})
+
+@Getter
+@MappedSuperclass
+public abstract class DateEntity {
+
+    @CreatedDate
+    private LocalDate createdAt;
+
+    @LastModifiedDate
+    private LocalDate modifiedAt;
+
+}

--- a/mylog/src/main/java/mylog_backend/mylog/memo/IsChecked.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/IsChecked.java
@@ -1,0 +1,6 @@
+package mylog_backend.mylog.memo;
+
+public enum IsChecked {
+    CHECKED, // 메모 체크 => is_visible = 0
+    UNCHECKED  // 메모 체크X => is_visible = 1
+}

--- a/mylog/src/main/java/mylog_backend/mylog/memo/Memo.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/Memo.java
@@ -1,0 +1,30 @@
+package mylog_backend.mylog.memo;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import mylog_backend.mylog.common.domain.DateEntity;
+
+@Entity
+@Getter
+public class Memo extends DateEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String memoContent;
+
+    @Enumerated(EnumType.STRING) // ENUM 타입을 String으로 지정
+    @Column(nullable = false)
+    private IsChecked isChecked;
+
+    // modifiedAt, CreatedAt 필드는 DataEntity에 존재
+
+    // TINYINT(1)을 이용해 0과 1로 표현
+    // 0: 논리적 삭제, 1: 공개
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
+    private byte isVisible;
+
+
+}


### PR DESCRIPTION
- DateEntity를 추상클래스로 정의하며, Spring Auditing 사용
- build.gradle에 메인과 테스트용으로 롬복 의존성 추가
- isChecked 필드를 ENUM타입으로 관리하기로 수정

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#5 


## 📝작업 내용
1. DateEntity를 추상클래스로 정의하였다. 메모와 일기 엔티티는 이 클래스를 상속받아서 정의된다.
2. DateEntity에 Spring Auditing을 사용하였다. 생성일자와 수정일자가 자동으로 관리된다. 단! JPA의 영속성이 유지되는한 보장된다!
3. Memo 엔티티를 정의했다.
- isChecked 필드는 ENUM 타입으로 관리된다.
- isVisible 필드는 TINYINT(1)로 관리된다.


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬해야할것(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- TINYINT(1)과 BOOLEAN 타입의 차이점과 타이니인트가 갖는 장점을 중심으로 노션에 정리하기