### PR TITLE
feat/#7 : 메모 생성 기능 구현

### DIFF
--- a/mylog/build.gradle
+++ b/mylog/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
+	// validation 추가
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 }
 
 tasks.named('test') {

--- a/mylog/src/main/java/mylog_backend/mylog/memo/Memo.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/Memo.java
@@ -1,11 +1,14 @@
 package mylog_backend.mylog.memo;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 import mylog_backend.mylog.common.domain.DateEntity;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE) // 매개변수 없이 객체 생성을 막음
+@RequiredArgsConstructor
+@Table(name="memo")
 public class Memo extends DateEntity {
 
     @Id
@@ -17,14 +20,24 @@ public class Memo extends DateEntity {
 
     @Enumerated(EnumType.STRING) // ENUM 타입을 String으로 지정
     @Column(nullable = false)
-    private IsChecked isChecked;
+    private IsChecked isChecked = IsChecked.UNCHECKED; // 기본값 설정
 
     // modifiedAt, CreatedAt 필드는 DataEntity에 존재
 
     // TINYINT(1)을 이용해 0과 1로 표현
     // 0: 논리적 삭제, 1: 공개
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
-    private byte isVisible;
+    private byte isVisible = 1;
+
+    @Builder
+    public Memo(Long id, String memoContent, IsChecked isChecked, byte isVisible) {
+        this.id = id;
+        this.memoContent = memoContent;
+        this.isChecked = isChecked;
+        this.isVisible = isVisible;
+    }
+
+
 
 
 }

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoController.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoController.java
@@ -1,0 +1,22 @@
+package mylog_backend.mylog.memo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@RequiredArgsConstructor
+public class MemoController {
+
+    private final MemoService memoService;
+
+    // 메모 생성
+    @PostMapping("/memos")
+    public ResponseEntity<MemoResponse> createMemo(@RequestBody MemoRequest request) {
+        MemoResponse response = memoService.createMemo(request);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+}

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoRepository.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoRepository.java
@@ -1,0 +1,11 @@
+package mylog_backend.mylog.memo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+// JpaRepository를 상속받는 MemoRepository 생성
+// 자동으로 구현체가 만들어져 MemoRepository 구현체가 사용됨
+@Repository
+public interface MemoRepository extends JpaRepository<Memo, Long> {
+
+}

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoRequest.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoRequest.java
@@ -1,0 +1,32 @@
+package mylog_backend.mylog.memo;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor // memoContent만 있으므로 기본 생성자 이용
+@AllArgsConstructor
+public class MemoRequest {
+
+    @NotNull
+    private String memoContent;
+
+    // 메모 생성/수정 일자는 저장시 자동으로 관리
+
+    // isChecked, isVisible는 메모 생성시 기본값 설정
+
+    // MemoRequest 생성자
+    // url별로 메모에 대한 매개변수가 필요할때 확장가능
+    @Builder
+    public MemoRequest(String memoContent, IsChecked isChecked, byte isVisible) {
+        this.memoContent = memoContent;
+    }
+
+    public Memo toMemo() {
+        return Memo.builder()
+                .memoContent(memoContent)
+                .build();
+    }
+
+}

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
@@ -1,0 +1,12 @@
+package mylog_backend.mylog.memo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class MemoResponse {
+
+    private String message;
+    private Long memoId;
+}

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoService.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoService.java
@@ -1,0 +1,21 @@
+package mylog_backend.mylog.memo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemoService {
+
+    private final MemoRepository memoRepository;
+
+    public MemoResponse createMemo(MemoRequest memoRequest) {
+        Memo memo = memoRequest.toMemo();
+        Memo savedMemo =  memoRepository.save(memo);
+
+        return new MemoResponse("메모가 저장되었습니다.", savedMemo.getId());
+    }
+
+
+
+}


### PR DESCRIPTION
- build.gradle에 validation 의존성 추가
- Memo의 생성자를 빌더 패턴으로 정의
- MemoRequest의 생성자도 빌더 패턴으로 정의
- toMemo 정적 메서드 구성

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#7 

## 📝작업 내용
- build.gradle에 validation 의존성 추가
- Memo의 생성자를 빌더 패턴으로 정의
- MemoRequest의 생성자도 빌더 패턴으로 정의
- toMemo 정적 메서드 구성

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
<img width="657" alt="image" src="https://github.com/user-attachments/assets/e734ae31-9b11-44e6-b419-860e631ac179" />

