### PR TITLE
feat/#13 : 단일 메모 조회 기능구현

### DIFF
--- a/mylog/src/main/java/mylog_backend/mylog/common/domain/DateEntity.java
+++ b/mylog/src/main/java/mylog_backend/mylog/common/domain/DateEntity.java
@@ -14,7 +14,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDate;
 
 @EntityListeners(value = {AuditingEntityListener.class})
-
 @Getter
 @MappedSuperclass
 public abstract class DateEntity {

--- a/mylog/src/main/java/mylog_backend/mylog/memo/Memo.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/Memo.java
@@ -17,7 +17,8 @@ public class Memo extends DateEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String memoContent;
 
     @Enumerated(EnumType.STRING) // ENUM 타입을 String으로 지정

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoController.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RequiredArgsConstructor
+@RestController // API 요청을 처리하기 위한 컨트롤러
 public class MemoController {
 
     private final MemoService memoService;
@@ -40,6 +41,15 @@ public class MemoController {
     public ResponseEntity<List<MemoResponse>> getVisibleMemos() {
         List<MemoResponse> memos = memoService.getVisibleMemos();
         return ResponseEntity.ok(memos);
+    }
+
+    /**
+     * 단일 메모 조회 기능
+     */
+    @GetMapping("/memos/{memoId}")
+    public ResponseEntity<MemoResponse> getMemo(@PathVariable Long memoId) {
+        MemoResponse response = memoService.getMemo(memoId);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
@@ -13,13 +13,15 @@ public class MemoResponse {
     private IsChecked isChecked;
     private IsVisible isVisible;
 
+    private String memoContent;
+
     @Builder
-    public MemoResponse(String message, Long memoId, IsVisible isVisible, IsChecked isChecked) {
+    public MemoResponse(String message, Long memoId, IsVisible isVisible, IsChecked isChecked, String memoContent) {
         this.memoId = memoId;
         this.message = message;
         this.isVisible = isVisible;
         this.isChecked = isChecked;
-    }
+        this.memoContent = memoContent;    }
 
 
     /**
@@ -47,6 +49,17 @@ public class MemoResponse {
                 .message(message)
                 .memoId(memoId)
                 .isChecked(isChecked)
+                .build();
+    }
+
+
+    // 단일 메모 조회에 이용되는 메서드
+    public static MemoResponse toMemo(String message, Long memoId, String memoContent, IsVisible isVisible) {
+        return MemoResponse.builder()
+                .memoId(memoId)
+                .message(message)
+                .memoContent(memoContent)
+                .isVisible(isVisible)
                 .build();
     }
 }

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoService.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoService.java
@@ -52,6 +52,28 @@ public class MemoService {
     }
 
 
+    /**
+     * 단일 메모 조회 메서드
+     * @param memoId
+     * @return
+     */
+    public MemoResponse getMemo(Long memoId) {
+        Memo memo = memoRepository.findById(memoId)
+                .orElseThrow(()-> new IllegalArgumentException("메모를 찾을 수 없습니다."));
+
+        if (memo.getIsVisible() == IsVisible.HIDDEN) {
+            throw new IllegalArgumentException("이전에 체크되어 조회할 수 없는 메모입니다.");
+        }
+
+        return MemoResponse.builder()
+                .message("단일 메모 조회 성공")
+                .memoId(memo.getId())
+                .isVisible(memo.getIsVisible())
+                .memoContent(memo.getMemoContent())
+                .isChecked(memo.getIsChecked())
+                .build();
+    }
+
 
 
 }

--- a/mylog/src/test/java/mylog_backend/mylog/memo/MemoServiceTest.java
+++ b/mylog/src/test/java/mylog_backend/mylog/memo/MemoServiceTest.java
@@ -1,6 +1,7 @@
 package mylog_backend.mylog.memo;
 
 import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -114,6 +115,37 @@ public class MemoServiceTest {
         // then
         assertThat(visibleMemos).hasSize(2);
 
+    }
+
+
+    @Test
+    @DisplayName("단일 메모 조회 테스트")
+    void getMemo() {
+
+        // given
+        Memo memo = Memo.builder()
+                .memoContent("음~메모~")
+                .isVisible(IsVisible.VISIBLE)
+                .build();
+
+        Memo savedMemo = memoRepository.save(memo);
+
+        // when
+        MemoResponse response = memoService.getMemo(savedMemo.getId());
+
+
+        // then
+        assertThat(response.getMemoId()).isEqualTo(savedMemo.getId());
+        assertThat(response.getMemoContent()).isEqualTo("음~메모~");
+        assertThat(response.getIsVisible()).isEqualTo(IsVisible.VISIBLE);
+
+    }
+
+
+    @Test
+    @DisplayName("존재하지 않는 메모 조회시 예외가 발생한다.")
+    void getNotExistMemo() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> memoService.getMemo(111L));
     }
 
 


### PR DESCRIPTION
- MemoController에 @RESTController 추가
- 단일 메모 조회 기능 구현
- 관련 테스트 코드 작성

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#13 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- MemoController에 @RESTController 추가
- 단일 메모 조회 기능 구현
- 관련 테스트 코드 작성


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
@Controller와 @RestController의 차이를 알아둬야겠다.
또, 서비스와 컨트롤러에 애노테이션을 붙이는걸 잊지말자

