### PR TITLE
feat/#15 : 일기 생성 기능 구현

### DIFF
--- a/mylog/src/main/java/mylog_backend/mylog/diary/Diary.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/Diary.java
@@ -1,0 +1,57 @@
+package mylog_backend.mylog.diary;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.*;
+import mylog_backend.mylog.common.domain.DateEntity;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "diary")
+public class Diary extends DateEntity {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String dairyTitle;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String dairyContent;
+
+    @Column(nullable = true)
+    @Enumerated(EnumType.STRING)
+    private Feeling feeling;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private IsPublic isPublic = IsPublic.PRIVATE;
+
+    @Column(nullable = true)
+    @Builder.Default
+    @Min(value = 0, message = "점수는 0 이상이여야 합니다.")
+    @Max(value = 100, message = "점수는 100 이하여야 합니다.")
+    private Integer feelingScore = 0;
+
+
+    // created_at, modified_at 필드는 DateEntity에 존재
+
+    // 생성자
+//    public Diary(String dairyTitle, String dairyContent, Feeling feeling, byte feelingScore, IsPublic isPublic) {
+//        this.dairyTitle = dairyTitle;
+//        this.dairyContent = dairyContent;
+//        this.feeling = feeling;
+//        this.feelingScore = feelingScore;
+//        this.isPublic = isPublic;
+//    }
+
+
+}

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryController.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryController.java
@@ -1,0 +1,27 @@
+package mylog_backend.mylog.diary;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    /**
+     * 일기 생성
+     * @param request
+     * @return
+     */
+    @PostMapping("/diaries")
+    public ResponseEntity<DiaryResponse> createDiary(@RequestBody DiaryRequest request) {
+        DiaryResponse response = diaryService.createDiary(request);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+}

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRepository.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRepository.java
@@ -1,0 +1,8 @@
+package mylog_backend.mylog.diary;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+}

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRequest.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRequest.java
@@ -1,0 +1,65 @@
+package mylog_backend.mylog.diary;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import mylog_backend.mylog.memo.Memo;
+import org.hibernate.sql.model.jdbc.MergeOperation;
+
+
+public class DiaryRequest {
+
+    @NotNull
+    private String diaryTitle;
+
+    @NotNull
+    private String diaryContent;
+
+    private Feeling feeling;
+
+    // 점수는 0 ~ 100 범위 내에서만 입력되어야함
+    @Min(value = 0, message = "감정 점수는 0 이상이어야 합니다")
+    @Max(value = 100, message = "감정 점수는 100 이하여야 합니다")
+    private Integer feelingScore;
+
+    @NotNull
+    private IsPublic isPublic;
+
+
+    /**
+     * 일기 요청 DTO 생성자
+     * @param diaryTitle
+     * @param diaryContent
+     * @param feeling
+     * @param feelingScore
+     * @param isPublic
+     */
+    @Builder
+    public DiaryRequest(String diaryTitle, String diaryContent, Feeling feeling, Integer feelingScore, IsPublic isPublic) {
+        this.diaryContent = diaryContent;
+        this.diaryTitle = diaryTitle;
+        this.feeling = feeling;
+        this.isPublic = isPublic;
+        this.feelingScore = feelingScore;
+    }
+
+    /**
+     * 일기 생성시 사용되는 변환 메서드
+     * 일기 내용 입력후 생성 요청 -> from()메서드로 변환 -> 비즈니스 로직 수행
+     * @return
+     */
+    public Diary from() {
+        return Diary.builder()
+                .dairyContent(diaryContent)
+                .dairyTitle(diaryTitle)
+                .feeling(feeling)
+                .feelingScore(feelingScore)
+                .isPublic(isPublic)
+                .build();
+    }
+
+
+
+}

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryResponse.java
@@ -1,0 +1,41 @@
+package mylog_backend.mylog.diary;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DiaryResponse {
+
+    private String message;
+
+    private Long diaryId;
+
+    /**
+     * 일기 응답 DTO 생성자
+     * 일기 관련 로직후 이용됨
+     * 로직이 다양해질수록 확장성을 띄도록 설계
+     * @param message
+     * @param diaryId
+     */
+    @Builder
+    public DiaryResponse(String message, Long diaryId) {
+        this.diaryId = diaryId;
+        this.message = message;
+        // 이후 응답DTO가 사용되는 형태에 따라서 필드 추가 가능
+    }
+
+
+    /**
+     * 단순 일기 관련 응답을 뱉을때 사용
+     * @param message : 로직 성공시 띄우는 메시지
+     * @param diaryId : 생성된 일기 아이디
+     * @return : 가공된 응답 DTO 틀을 이용해 반환
+     */
+    public static DiaryResponse of(String message, Long diaryId) {
+        return DiaryResponse.builder()
+                .message(message)
+                .diaryId(diaryId)
+                .build();
+    }
+
+}

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryService.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryService.java
@@ -1,0 +1,19 @@
+package mylog_backend.mylog.diary;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+
+    public DiaryResponse createDiary(DiaryRequest request) {
+        Diary diary = request.from();
+        Diary savedDiary = diaryRepository.save(diary);
+
+        return DiaryResponse.of("일기가 성공적으로 생성되었습니다.", savedDiary.getId());
+    }
+
+}

--- a/mylog/src/main/java/mylog_backend/mylog/diary/Feeling.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/Feeling.java
@@ -1,0 +1,9 @@
+package mylog_backend.mylog.diary;
+
+public enum Feeling {
+    HAPPY,
+    SAD,
+    ANGRY,
+    NOT_BAD
+
+}

--- a/mylog/src/main/java/mylog_backend/mylog/diary/IsPublic.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/IsPublic.java
@@ -1,0 +1,7 @@
+package mylog_backend.mylog.diary;
+
+public enum IsPublic {
+    PRIVATE, // 나만 접근 가능
+    PUBLIC, // 모두가 접근 가능
+    FRIEND // 친구만 접근 가능
+}

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
@@ -31,9 +31,9 @@ public class MemoResponse {
      * 2. 메모 조회 성공
      * 3. 메모 목록 조회 성공
      *
-     * @param message
-     * @param memoId
-     * @return
+     * @param message : 로직 성공시 띄울 메시지
+     * @param memoId : 생성된/저장된 메모의 아이디
+     * @return : 응답 DTO 틀을 이용하여 값을 할당후 반환
      */
     public static MemoResponse of(String message, Long memoId) {
         return MemoResponse.builder()

--- a/mylog/src/test/java/mylog_backend/mylog/diary/DiaryServiceTest.java
+++ b/mylog/src/test/java/mylog_backend/mylog/diary/DiaryServiceTest.java
@@ -1,0 +1,87 @@
+package mylog_backend.mylog.diary;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class DiaryServiceTest {
+
+    @Autowired private DiaryService diaryService;
+    @Autowired private DiaryRepository diaryRepository;
+
+
+    @Test
+    @DisplayName("일기 생성 로직 테스트")
+    void createDiary() {
+        // given
+        DiaryRequest request = DiaryRequest.builder()
+                .diaryTitle("테스트일기")
+                .diaryContent("엄마저는잘지내요테커사람들이코딩을잘가르쳐줘요")
+                .feeling(Feeling.SAD)
+                .feelingScore(30)
+                .isPublic(IsPublic.PRIVATE)
+                .build();
+
+        // when
+        DiaryResponse response = diaryService.createDiary(request);
+
+        // then
+        assertThat(response.getDiaryId()).isNotNull();
+
+        Diary savedDiary = diaryRepository.findById(response.getDiaryId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 일기는 존재하지 않습니다."));
+
+        assertThat(savedDiary.getDairyTitle()).isEqualTo("테스트일기");
+        assertThat(savedDiary.getDairyContent()).isEqualTo("엄마저는잘지내요테커사람들이코딩을잘가르쳐줘요");
+        assertThat(savedDiary.getFeeling()).isEqualTo(Feeling.SAD);
+        assertThat(savedDiary.getIsPublic()).isEqualTo(IsPublic.PRIVATE);
+        assertThat(savedDiary.getFeelingScore()).isEqualTo(30);
+
+    }
+
+
+    @Test
+    @DisplayName("일기 점수는 0부터 100까지만 입력되어야 한다.")
+    public void validScore() {
+
+        // given
+        DiaryRequest request1 = DiaryRequest.builder()
+                .diaryTitle("테스트일기")
+                .diaryContent("엄마저는잘지내요테커사람들이코딩을잘가르쳐줘요")
+                .feeling(Feeling.SAD)
+                .feelingScore(-111)
+                .isPublic(IsPublic.PRIVATE)
+                .build();
+
+        DiaryRequest request2= DiaryRequest.builder()
+                .diaryTitle("테스트일기")
+                .diaryContent("엄마저는잘지내요테커사람들이코딩을잘가르쳐줘요")
+                .feeling(Feeling.SAD)
+                .feelingScore(111)
+                .isPublic(IsPublic.PRIVATE)
+                .build();
+
+
+        // when / then
+        assertThrows(ConstraintViolationException.class, () -> {
+            diaryService.createDiary(request1);});
+        assertThrows(ConstraintViolationException.class, () -> {
+            diaryService.createDiary(request2);});
+
+
+
+    }
+
+
+
+
+}

--- a/mylog/src/test/java/mylog_backend/mylog/memo/MemoServiceTest.java
+++ b/mylog/src/test/java/mylog_backend/mylog/memo/MemoServiceTest.java
@@ -9,7 +9,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/mylog/src/test/resources/application-test.yml
+++ b/mylog/src/test/resources/application-test.yml
@@ -11,7 +11,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
   h2:
     console:
       enabled: true


### PR DESCRIPTION
- 일기 생성 로직 구현
- 일기 생성, 점수 유효성 테스트 코드 작성
- 감정과 점수 컬럼의 형태가 SAMLLINT -> VARCHAR 수정

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#15 

## 📝작업 내용
- 일기 생성 로직 구현
- 일기 생성, 점수 유효성 테스트 코드 작성
- 감정과 점수 컬럼의 형태가 SAMLLINT -> VARCHAR 수정


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
