### PR TITLE
doc/#21 : Swagger UI 문서화

### DIFF
--- a/mylog/src/main/java/mylog_backend/mylog/auth/AuthController.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/AuthController.java
@@ -1,5 +1,7 @@
 package mylog_backend.mylog.auth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "인증", description = "회원가입, 로그인, 로그아웃 관련 API")
 @RestController
 @RequiredArgsConstructor
 public class AuthController {
@@ -25,6 +28,7 @@ public class AuthController {
      * @param request : 회원가입 요청
      * @return : 성공 확인
      */
+    @Operation(summary = "회원가입", description = "회원가입을 할 수 있습니다.")
     @PostMapping("/auth/signup")
     private ResponseEntity<Void> singup(@RequestBody @Valid SignupRequest request) {
         userService.signup(request);
@@ -37,10 +41,11 @@ public class AuthController {
      * @param request
      * @return
      */
-    @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestBody @Valid LoginRequest request) {
-        userService.login(request);
-        return ResponseEntity.ok().build();
+    @Operation(summary = "로그인", description = "로그인시 토큰을 받습니다.")
+    @PostMapping("/auth/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
+        LoginResponse response = userService.login(request);
+        return ResponseEntity.ok(response);
     }
 
 
@@ -49,6 +54,7 @@ public class AuthController {
      * @param request
      * @return
      */
+    @Operation(summary = "로그아웃", description = "로그아웃을 할 시 토큰이 반납됩니다.")
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletRequest request) {
         // 헤더에서 토큰을 꺼냄

--- a/mylog/src/main/java/mylog_backend/mylog/auth/LoginRequest.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/LoginRequest.java
@@ -1,16 +1,21 @@
 package mylog_backend.mylog.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import mylog_backend.mylog.user.User;
 
+@Schema(description = "로그인 요청 DTO")
 @Getter
 public class LoginRequest {
 
+    @Schema(description = "사용자 아이디", example = "daiseek123")
     @NotBlank(message = "아이디를 입력해주세요.")
     private String loginId;
 
+    @Schema(description = "사용자 비밀번호", example = "1234")
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 

--- a/mylog/src/main/java/mylog_backend/mylog/auth/LoginResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/LoginResponse.java
@@ -1,11 +1,21 @@
 package mylog_backend.mylog.auth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Schema(description = "로그인 응답 DTO")
 @Getter
 @AllArgsConstructor
 public class LoginResponse {
+
+    @Schema(description = "사용자 토큰")
+    @NotBlank
     private String accessToken;
+
+    @Schema(description = "사용자 이름")
+    @NotBlank
     private String userName;
 }

--- a/mylog/src/main/java/mylog_backend/mylog/auth/SecurityConfig.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/SecurityConfig.java
@@ -23,6 +23,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/auth/**",  // 🔑 회원가입, 로그인 등은 인증 없이 허용
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",

--- a/mylog/src/main/java/mylog_backend/mylog/auth/SignupRequest.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/SignupRequest.java
@@ -1,5 +1,6 @@
 package mylog_backend.mylog.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,12 +12,15 @@ import mylog_backend.mylog.user.User;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SignupRequest {
 
+    @Schema(description = "사용자 아이디", example = "daiseek123")
     @NotBlank(message = "아이디를 입력해주세요.")
     private String loginId;
 
+    @Schema(description = "사용자 이름", example = "daiseek")
     @NotBlank(message = "이름을 입력해주세요.")
     private String userName;
 
+    @Schema(description = "사용자 비밃번호", example = "1234")
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryController.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryController.java
@@ -1,5 +1,7 @@
 package mylog_backend.mylog.diary;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "일기", description = "일기 관련 API")
 @RequiredArgsConstructor
 @RestController
 public class DiaryController {
@@ -18,6 +21,7 @@ public class DiaryController {
      * @param request
      * @return
      */
+    @Operation(summary = "일기 생성", description = "일기를 생성합니다.")
     @PostMapping("/diaries")
     public ResponseEntity<DiaryResponse> createDiary(@RequestBody DiaryRequest request) {
         DiaryResponse response = diaryService.createDiary(request);

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRequest.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRequest.java
@@ -1,29 +1,37 @@
 package mylog_backend.mylog.diary;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import mylog_backend.mylog.memo.Memo;
 import org.hibernate.sql.model.jdbc.MergeOperation;
 
-
+@Schema(description = "일기 요청 DTO")
+@Getter
 public class DiaryRequest {
 
+    @Schema(description = "일기 제목", example = "123")
     @NotNull
     private String diaryTitle;
 
+    @Schema(description = "일기 내용", example = "엄마저는잘지내요테커사람들이코딩을잘가르쳐줘요...")
     @NotNull
     private String diaryContent;
 
+    @Schema(description = "감정 상태", example = "HAPPY")
     private Feeling feeling;
 
+    @Schema(description = "감정 점수", example = "30")
     // 점수는 0 ~ 100 범위 내에서만 입력되어야함
     @Min(value = 0, message = "감정 점수는 0 이상이어야 합니다")
     @Max(value = 100, message = "감정 점수는 100 이하여야 합니다")
     private Integer feelingScore;
 
+    @Schema(description = "일기 공개 여부", example = "PRIVATE")
     @NotNull
     private IsPublic isPublic;
 

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryResponse.java
@@ -1,13 +1,17 @@
 package mylog_backend.mylog.diary;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+@Schema(description = "일기 API 요청후 응답으로 나온 결과물을 담는 DTO입니다.")
 @Getter
 public class DiaryResponse {
 
+    @Schema(description = "성공시 메시지와 함께 결과물이 반환됩니다.", example = "일기 요청 성공")
     private String message;
 
+    @Schema(description = "db에 저장되어있는 일기의 아이디입니다.", example = "123")
     private Long diaryId;
 
     /**

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoController.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoController.java
@@ -1,5 +1,7 @@
 package mylog_backend.mylog.memo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "메모", description = "메모 관련 API")
 @RequiredArgsConstructor
 @RestController // API 요청을 처리하기 위한 컨트롤러
 public class MemoController {
@@ -18,6 +21,7 @@ public class MemoController {
      * @param request
      * @return
      */
+    @Operation(summary = "메모 생성", description = "새 메모를 생성합니다.")
     @PostMapping("/memos")
     public ResponseEntity<MemoResponse> createMemo(@RequestBody MemoRequest request) {
         MemoResponse response = memoService.createMemo(request);
@@ -28,6 +32,7 @@ public class MemoController {
     /**
      * 메모 제거 기능
      */
+    @Operation(summary = "메모 확인 표시", description = "메모를 체크했을때 논리적 삭제가 이루어집니다.")
     @PatchMapping("/memos/{memoId}")
     public ResponseEntity<MemoResponse> checkedMemo(@PathVariable Long memoId) {
         MemoResponse response = memoService.checkedMemo(memoId);
@@ -37,6 +42,7 @@ public class MemoController {
     /**
      * 메모 목록 조회 기능
      */
+    @Operation(summary = "메모 목록 조회", description = "체크되지 않은 메모들을 불러옵니다.")
     @GetMapping("/memos")
     public ResponseEntity<List<MemoResponse>> getVisibleMemos() {
         List<MemoResponse> memos = memoService.getVisibleMemos();
@@ -46,6 +52,7 @@ public class MemoController {
     /**
      * 단일 메모 조회 기능
      */
+    @Operation(summary = "단일 메모 조회", description = "메모를 하나씩 조회합니다.")
     @GetMapping("/memos/{memoId}")
     public ResponseEntity<MemoResponse> getMemo(@PathVariable Long memoId) {
         MemoResponse response = memoService.getMemo(memoId);

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoRequest.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoRequest.java
@@ -1,15 +1,21 @@
 package mylog_backend.mylog.memo;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+
+@Schema(name = "메모 요청 DTO", description = "메모 요청 DTO")
 @RequiredArgsConstructor // memoContent만 있으므로 기본 생성자 이용
 @AllArgsConstructor
 @Builder
+@Getter // Swagger UI를 위함
 public class MemoRequest {
 
+    @Schema(description = "메모 내용", example = "약국에서 영양제 구매하기")
     @NotNull
     private String memoContent;
 

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
@@ -1,18 +1,26 @@
 package mylog_backend.mylog.memo;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+@Schema(description = "메모 관련 요청 처리후 결과물을 담는 응답 DTO입니다.")
 @Getter
 public class MemoResponse {
 
+    @Schema(description = "API 요청 성공시 결과물과 함께 반환됩니다.", example = "메모 요청 성공")
     private String message;
+
+    @Schema(description = "DB에서 저장된 메모의 id", example = "123")
     private Long memoId;
 
+    @Schema(description = "메모 체크시 상태가 달라집니다.", example = "CHECKED")
     private IsChecked isChecked;
+    @Schema(description = "체크 상태가 되면 안보입니다.", example = "HIDDEN")
     private IsVisible isVisible;
 
+    @Schema(description = "db에 저장된 메모 내용입니다.", example = "약국에서 영양제 사기")
     private String memoContent;
 
     @Builder

--- a/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceController.java
+++ b/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceController.java
@@ -1,17 +1,21 @@
 package mylog_backend.mylog.preference;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "사용자 선호태그", description = "사용자의 선호 태그 관련 API")
 @RestController
 @RequiredArgsConstructor
 public class PreferenceController {
 
     private final PreferenceService preferenceService;
 
+    @Operation(summary = "선호 태그 입력",description = "사용자 선호 태그를 받아낸다.")
     @PostMapping("/preferences")
     public ResponseEntity<Void> savePreferences(@RequestBody PreferenceRequest request) {
         preferenceService.savePreferences(request);  // ✅ 전체 request 객체 전달

--- a/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceRequest.java
+++ b/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceRequest.java
@@ -1,16 +1,20 @@
 package mylog_backend.mylog.preference;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
+@Schema(description = "사용자 선호 요청 DTO")
 @Getter
 public class PreferenceRequest {
 
+    @Schema(description = "사용자 선호 태그1", example = "공부")
     private String tag1;
 
+    @Schema(description = "사용자 선호 태그2", example = "클래식")
     private String tag2;
 
 

--- a/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceResponse.java
@@ -1,12 +1,17 @@
 package mylog_backend.mylog.preference;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+@Schema(description = "사용자 선호 응답 DTO")
 public class PreferenceResponse {
 
+    @Schema(description = "응답 성공 메시지", example = "선호 태그 요청 성공")
     private String message;
 
+    @Schema(description = "선호 태그1 아이디", example = "1")
     private Integer preferenceId1;
+    @Schema(description = "선호 태그2 아이디", example = "2")
     private Integer preferenceId2;
 
     @Builder

--- a/mylog/src/main/java/mylog_backend/mylog/swagger/SwaggerConfig.java
+++ b/mylog/src/main/java/mylog_backend/mylog/swagger/SwaggerConfig.java
@@ -1,0 +1,33 @@
+package mylog_backend.mylog.swagger;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("MyLog API")
+                        .version("1.0.0")
+                        .description("MyLog 프로젝트 Swagger 문서"))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new io.swagger.v3.oas.models.Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .name(SECURITY_SCHEME_NAME)
+                                .type(Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}

--- a/mylog/src/test/java/mylog_backend/mylog/prerence/PreferenceServiceTest.java
+++ b/mylog/src/test/java/mylog_backend/mylog/prerence/PreferenceServiceTest.java
@@ -1,0 +1,48 @@
+package mylog_backend.mylog.prerence;
+
+import mylog_backend.mylog.preference.Preference;
+import mylog_backend.mylog.preference.PreferenceRepository;
+import mylog_backend.mylog.preference.PreferenceRequest;
+import mylog_backend.mylog.preference.PreferenceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class PreferenceServiceTest {
+
+    @Autowired
+    private PreferenceService preferenceService;
+    
+    @Autowired
+    private PreferenceRepository preferenceRepository;
+
+    @Test
+    @DisplayName("선호도 태그 저장 테스트")
+    void savePreferences() {
+        // given
+        PreferenceRequest request = PreferenceRequest.builder()
+                .tag1("운동")
+                .tag2("독서")
+                .build();
+
+        // when
+        preferenceService.savePreferences(request);
+
+        // then
+        List<Preference> savedPreferences = preferenceRepository.findAll();
+        
+        assertThat(savedPreferences).hasSize(2);
+        assertThat(savedPreferences)
+                .extracting("tag")
+                .containsExactlyInAnyOrder("운동", "독서");
+    }
+}


### PR DESCRIPTION
- swagger 페이지가 뜨는 것을 확인
- 이후에 User 엔티티와 다른 엔티티간에 연관관계를 맺어주는 행위가 필요함

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#21 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="1337" alt="image" src="https://github.com/user-attachments/assets/de4e8b8b-f462-4739-b168-c89cb2a75fa5" />


- swagger 페이지가 뜨는 것을 확인
- 이후에 User 엔티티와 다른 엔티티간에 연관관계를 맺어주는 행위가 필요함

엔티티와 DTO에 swagger애노테이션을 통해 문서화함
`http://localhost:8080/swagger-ui/index.html` 로 접속 성공
이후 회원가입, 로그인 기능을 통해 사용자 생성후 JWT 토큰을 받는 행위까진 성공했으나...
메모나 일기 생성 API에서 403 상태 코드가 나옴.
해결책이 필요함. 노션에 더 자세하게 정리하겠음



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
