### PR TITLE
fix/#29 : 일기 <-> 사용자간 연관관계 매핑

### DIFF
--- a/mylog/src/main/java/mylog_backend/mylog/diary/Diary.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/Diary.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.*;
 import mylog_backend.mylog.common.domain.DateEntity;
+import mylog_backend.mylog.user.User;
 
 @Entity
 @Getter
@@ -44,14 +45,28 @@ public class Diary extends DateEntity {
 
     // created_at, modified_at 필드는 DateEntity에 존재
 
-    // 생성자
-//    public Diary(String dairyTitle, String dairyContent, Feeling feeling, byte feelingScore, IsPublic isPublic) {
-//        this.dairyTitle = dairyTitle;
-//        this.dairyContent = dairyContent;
-//        this.feeling = feeling;
-//        this.feelingScore = feelingScore;
-//        this.isPublic = isPublic;
-//    }
+//     생성자
+    public Diary(String dairyTitle, String dairyContent, Feeling feeling, Integer feelingScore, IsPublic isPublic) {
+        this.dairyTitle = dairyTitle;
+        this.dairyContent = dairyContent;
+        this.feeling = feeling;
+        this.feelingScore = feelingScore;
+        this.isPublic = isPublic;
+    }
+
+
+    /**
+     * 사용자 <-> 메모
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 사용자 세팅
+    public void setUser(User user) {
+        this.user = user;
+    }
+
 
 
 }

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryController.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryController.java
@@ -3,11 +3,13 @@ package mylog_backend.mylog.diary;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import mylog_backend.mylog.auth.UserPrincipal;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "일기", description = "일기 관련 API")
 @RequiredArgsConstructor
@@ -23,9 +25,31 @@ public class DiaryController {
      */
     @Operation(summary = "일기 생성", description = "일기를 생성합니다.")
     @PostMapping("/diaries")
-    public ResponseEntity<DiaryResponse> createDiary(@RequestBody DiaryRequest request) {
-        DiaryResponse response = diaryService.createDiary(request);
+    public ResponseEntity<DiaryResponse> createDiary(@RequestBody DiaryRequest request, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getId();
+
+        DiaryResponse response = diaryService.createDiary(userId, request);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+
+    @Operation(summary = "일기 목록 조회")
+    @GetMapping("/diaries")
+    public ResponseEntity<List<DiaryResponse>> getDiaries(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getId();
+
+        List<DiaryResponse> diaries = diaryService.getDiaries(userId);
+        return ResponseEntity.ok(diaries);
+    }
+
+
+    @Operation(summary = "단일 일기 조회")
+    @GetMapping("/diaries/{diaryId}")
+    public ResponseEntity<DiaryResponse> getDiary(@PathVariable Long diaryId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getId();
+
+        DiaryResponse response = diaryService.getDiary(userId, diaryId);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRepository.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRepository.java
@@ -3,6 +3,23 @@ package mylog_backend.mylog.diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    /**
+     * 유저 아이디를 기준으로 모든 일기를 서치
+     * @param userId
+     * @return
+     */
+    List<Diary> findAllByUserId(Long userId);
+
+
+    /**
+     * 유저 아이디를 기준으로 단일 일기 조회
+     * @param userId
+     * @return
+     */
+    Diary findByUserId(Long userId);
 }

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryResponse.java
@@ -3,6 +3,7 @@ package mylog_backend.mylog.diary;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+import mylog_backend.mylog.memo.MemoResponse;
 
 @Schema(description = "일기 API 요청후 응답으로 나온 결과물을 담는 DTO입니다.")
 @Getter
@@ -14,6 +15,23 @@ public class DiaryResponse {
     @Schema(description = "db에 저장되어있는 일기의 아이디입니다.", example = "123")
     private Long diaryId;
 
+    @Schema(description = "일기 내용")
+    private String dairyContent;
+
+    @Schema(description = "일기 제목")
+    private String dairyTitle;
+
+    @Schema(description = "공개 여부")
+    private IsPublic isPublic;
+
+    @Schema(description = "감정")
+    private Feeling feeling;
+
+    @Schema(description = "감정 점수")
+    private Integer feelingScore;
+
+
+
     /**
      * 일기 응답 DTO 생성자
      * 일기 관련 로직후 이용됨
@@ -22,10 +40,43 @@ public class DiaryResponse {
      * @param diaryId
      */
     @Builder
-    public DiaryResponse(String message, Long diaryId) {
+    public DiaryResponse(String message, Long diaryId, String dairyTitle,
+                         String dairyContent, Feeling feeling,
+                         IsPublic isPublic, Integer feelingScore) {
         this.diaryId = diaryId;
         this.message = message;
+        this.dairyContent = dairyContent;
+        this.dairyTitle = dairyTitle;
+        this.isPublic = isPublic;
+        this.feeling = feeling;
+        this.feelingScore = feelingScore;
         // 이후 응답DTO가 사용되는 형태에 따라서 필드 추가 가능
+    }
+
+
+    /**
+     * 일기 단건/목록 조회시 사용
+     * @param message
+     * @param diaryId
+     * @param dairyTitle
+     * @param dairyContent
+     * @param feeling
+     * @param isPublic
+     * @param feelingScore
+     * @return
+     */
+    public static DiaryResponse toDiary(String message, Long diaryId, String dairyTitle,
+                                        String dairyContent, Feeling feeling,
+                                        IsPublic isPublic, Integer feelingScore) {
+        return DiaryResponse.builder()
+                .message(message)
+                .diaryId(diaryId)
+                .dairyTitle(dairyTitle)
+                .dairyContent(dairyContent)
+                .isPublic(isPublic)
+                .feeling(feeling)
+                .feelingScore(feelingScore)
+                .build();
     }
 
 
@@ -41,5 +92,6 @@ public class DiaryResponse {
                 .diaryId(diaryId)
                 .build();
     }
+
 
 }

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryService.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryService.java
@@ -1,19 +1,89 @@
 package mylog_backend.mylog.diary;
 
 import lombok.RequiredArgsConstructor;
+import mylog_backend.mylog.common.exception.UserNotFoundException;
+import mylog_backend.mylog.memo.MemoResponse;
+import mylog_backend.mylog.user.User;
+import mylog_backend.mylog.user.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class DiaryService {
 
     private final DiaryRepository diaryRepository;
+    private final UserRepository userRepository;
 
-    public DiaryResponse createDiary(DiaryRequest request) {
+    /**
+     * 1. 일기 생성 메서드
+     * @param userId : 유저 아이디
+     * @param request : 프론트에게 일기에 대한 내용을 입력받음
+     * @return : 응답을 가공하여 반환
+     */
+    @Transactional
+    public DiaryResponse createDiary(Long userId , @RequestBody DiaryRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
         Diary diary = request.from();
+
+        user.addDiary(diary);
+
         Diary savedDiary = diaryRepository.save(diary);
 
         return DiaryResponse.of("일기가 성공적으로 생성되었습니다.", savedDiary.getId());
+    }
+
+
+    /**
+     * 2. 일기 목록 조회 메서드
+     * @param userId
+     * @return
+     */
+    @Transactional
+    public List<DiaryResponse> getDiaries(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        return diaryRepository.findAllByUserId(userId)
+                .stream()
+                .map(diary -> DiaryResponse.toDiary(
+                        "일기 목록 조회 성공",
+                        diary.getId(),
+                        diary.getDairyTitle(),
+                        diary.getDairyContent(),
+                        diary.getFeeling(),
+                        diary.getIsPublic(),
+                        diary.getFeelingScore()))
+                .collect(Collectors.toList());
+    }
+
+
+    /**
+     * 3. 일기 단건 조회 메서드
+     * @param userId
+     * @param diaryId
+     * @return
+     */
+    @Transactional
+    public DiaryResponse getDiary(Long userId, Long diaryId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(()-> new IllegalArgumentException("메모를 찾을 수 없습니다."));
+
+        return DiaryResponse.builder()
+                .message("단일 일기 조회 성공")
+                .diaryId(diary.getId())
+                .dairyTitle(diary.getDairyTitle())
+                .dairyContent(diary.getDairyContent())
+                .feeling(diary.getFeeling())
+                .feelingScore(diary.getFeelingScore())
+                .isPublic(diary.getIsPublic())
+                .build();
+
     }
 
 }

--- a/mylog/src/main/java/mylog_backend/mylog/user/User.java
+++ b/mylog/src/main/java/mylog_backend/mylog/user/User.java
@@ -2,6 +2,7 @@ package mylog_backend.mylog.user;
 
 import jakarta.persistence.*;
 import lombok.*;
+import mylog_backend.mylog.diary.Diary;
 import mylog_backend.mylog.memo.Memo;
 import mylog_backend.mylog.preference.Preference;
 
@@ -90,4 +91,30 @@ public class User {
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("해당 메모가 없습니다."));
     }
+
+
+    /**
+     * 3. 일기 <-> 사용자
+     * 회원 : 일기 = 1:N
+     */
+    @OneToMany(mappedBy = "user", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<Diary> diaries = new ArrayList<>();
+    // 일기 생성 메서드
+    public void addDiary(Diary diary) {
+        diary.setUser(this);
+        diaries.add(diary);
+    }
+    // 메모 목록 조회 메서드
+    public List<Diary> getDiaries() {
+        return diaries;
+    }
+    // 단일 메모 조회 메서드
+    public Memo getDiary(Long diaryId) {
+        return memos.stream()
+                .filter(m -> m.getId().equals(diaryId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당 메모가 없습니다."));
+    }
+
+
 }

--- a/mylog/src/test/java/mylog_backend/mylog/diary/DiaryServiceTest.java
+++ b/mylog/src/test/java/mylog_backend/mylog/diary/DiaryServiceTest.java
@@ -2,12 +2,17 @@ package mylog_backend.mylog.diary;
 
 import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
+import mylog_backend.mylog.user.User;
+import mylog_backend.mylog.user.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -17,6 +22,54 @@ public class DiaryServiceTest {
 
     @Autowired private DiaryService diaryService;
     @Autowired private DiaryRepository diaryRepository;
+    @Autowired private UserRepository userRepository;
+
+
+    protected User testUser;
+    protected DiaryRequest request1;
+    protected DiaryRequest request2;
+    protected DiaryResponse response1;
+    protected DiaryResponse response2;
+
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .loginId("testId1234")
+                .email("test@example.com")
+                .password("encoded-password")
+                .userName("테스트유저")
+                .build();
+        userRepository.save(testUser);
+
+        DiaryRequest request1 = DiaryRequest.builder()
+                .diaryTitle("테스트일기1")
+                .diaryContent("엄마저는잘지내요테커사람들이코딩을잘가르쳐줘요")
+                .feeling(Feeling.SAD)
+                .feelingScore(30)
+                .isPublic(IsPublic.PRIVATE)
+                .build();
+        response1 = diaryService.createDiary(testUser.getId(), request1);
+
+        DiaryRequest request2 = DiaryRequest.builder()
+                .diaryTitle("테스트일기2")
+                .diaryContent("안녕하세요?")
+                .feeling(Feeling.HAPPY)
+                .feelingScore(50)
+                .isPublic(IsPublic.PUBLIC)
+                .build();
+        response2 = diaryService.createDiary(testUser.getId(), request2);
+
+    }
+
+
+    // 테스트후 정보 비워줌
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll(); // 또는 모든 repository 초기화
+    }
+
+
 
 
     @Test
@@ -32,7 +85,7 @@ public class DiaryServiceTest {
                 .build();
 
         // when
-        DiaryResponse response = diaryService.createDiary(request);
+        DiaryResponse response = diaryService.createDiary(testUser.getId(),request);
 
         // then
         assertThat(response.getDiaryId()).isNotNull();
@@ -46,6 +99,8 @@ public class DiaryServiceTest {
         assertThat(savedDiary.getIsPublic()).isEqualTo(IsPublic.PRIVATE);
         assertThat(savedDiary.getFeelingScore()).isEqualTo(30);
 
+        assertThat(savedDiary.getUser().getId()).isEqualTo(testUser.getId());
+
     }
 
 
@@ -54,7 +109,7 @@ public class DiaryServiceTest {
     public void validScore() {
 
         // given
-        DiaryRequest request1 = DiaryRequest.builder()
+        DiaryRequest testRequest1 = DiaryRequest.builder()
                 .diaryTitle("테스트일기")
                 .diaryContent("엄마저는잘지내요테커사람들이코딩을잘가르쳐줘요")
                 .feeling(Feeling.SAD)
@@ -62,7 +117,7 @@ public class DiaryServiceTest {
                 .isPublic(IsPublic.PRIVATE)
                 .build();
 
-        DiaryRequest request2= DiaryRequest.builder()
+        DiaryRequest testRequest2= DiaryRequest.builder()
                 .diaryTitle("테스트일기")
                 .diaryContent("엄마저는잘지내요테커사람들이코딩을잘가르쳐줘요")
                 .feeling(Feeling.SAD)
@@ -73,11 +128,32 @@ public class DiaryServiceTest {
 
         // when / then
         assertThrows(ConstraintViolationException.class, () -> {
-            diaryService.createDiary(request1);});
+            diaryService.createDiary(testUser.getId() , testRequest1);});
         assertThrows(ConstraintViolationException.class, () -> {
-            diaryService.createDiary(request2);});
+            diaryService.createDiary(testUser.getId(), testRequest2);});
+
+    }
 
 
+    @Test
+    @DisplayName("일기 조회 테스트")
+    void getDiary() {
+        // given
+        Diary savedDiary = diaryRepository.findById(response2.getDiaryId())
+                .orElseThrow(() -> new IllegalArgumentException("일기를 찾을 수 없습니다."));
+
+        // when
+        DiaryResponse testResponse = diaryService.getDiary(testUser.getId(), savedDiary.getId());
+
+        // then
+        assertThat(testResponse.getDiaryId()).isEqualTo(savedDiary.getId());
+        assertThat(testResponse.getDairyTitle()).isEqualTo("테스트일기2");
+        assertThat(testResponse.getDairyContent()).isEqualTo("안녕하세요?");
+        assertThat(testResponse.getIsPublic()).isEqualTo(IsPublic.PUBLIC);
+        assertThat(testResponse.getFeeling()).isEqualTo(Feeling.HAPPY);
+        assertThat(testResponse.getFeelingScore()).isEqualTo(50);
+
+        assertThat(savedDiary.getUser().getId()).isEqualTo(testUser.getId());
 
     }
 


### PR DESCRIPTION
- Diary, User 엔티티에 연관관계 세팅
- DiaryService/Controller 로직 수정
- DiaryResponse의 toDiary 구성변수 추가
- DiaryService 통합 테스트 코드 작성

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#29 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- Diary, User 엔티티에 연관관계 세팅
- DiaryService/Controller 로직 수정
- DiaryResponse의 toDiary 구성변수 추가
- DiaryService 통합 테스트 코드 작성

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
