### PR TITLE
Fix/#31: Swagger로 API 문서화

### DIFF
--- a/mylog/build.gradle
+++ b/mylog/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
 
 	// swagger UI를 위한 문서화 의존성
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	// JVM 환경 변수 세팅
 	implementation 'io.github.cdimascio:dotenv-java:2.2.4'

--- a/mylog/docker-compose.yml
+++ b/mylog/docker-compose.yml
@@ -25,6 +25,13 @@ services:
     image: "redis:latest"
     ports:
       - "6379:6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ] # Redis 서버가 응답하는지 확인
+      interval: 1s # 1초마다 체크
+      timeout: 3s # 3초 내에 응답 없으면 실패
+      retries: 30 # 최대 30번 (30초) 재시도
+      start_period: 5s # 컨테이너 시작 후 5초 동안은 헬스 체크 실패해도 무시
+      # --- 여기까지 추가/수정 ---
 
   application:
     build: .
@@ -32,9 +39,12 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - postgres
-      - rabbitmq
-      - redis
+      postgres:
+        condition: service_started # postgres는 기본적으로 시작만 되면 됨
+      rabbitmq:
+        condition: service_started # rabbitmq도 시작만 되면 됨
+      redis:
+        condition: service_healthy # ★ Redis가 'healthy' 상태가 될 때까지 기다림
     environment:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/${POSTGRES_DB}
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}

--- a/mylog/src/main/java/mylog_backend/mylog/KeyGenerator.java
+++ b/mylog/src/main/java/mylog_backend/mylog/KeyGenerator.java
@@ -1,0 +1,15 @@
+package mylog_backend.mylog;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.util.Base64;
+
+public class KeyGenerator {
+    public static void main(String[] args) {
+        // HS256 알고리즘에 적합한 256비트(32바이트) 이상의 강력한 키를 생성하고 Base64로 인코딩합니다.
+        String base64Key = Base64.getEncoder().encodeToString(Keys.secretKeyFor(SignatureAlgorithm.HS256).getEncoded());
+        System.out.println("새로운 Base64 인코딩된 JWT_SECRET_KEY:");
+        System.out.println(base64Key);
+        System.out.println("\n이 키를 .env 파일의 JWT_SECRET_KEY 값으로 사용하세요.");
+    }
+}

--- a/mylog/src/main/java/mylog_backend/mylog/UserPrincipalTest.java
+++ b/mylog/src/main/java/mylog_backend/mylog/UserPrincipalTest.java
@@ -1,0 +1,36 @@
+package mylog_backend.mylog;
+
+import mylog_backend.mylog.auth.UserPrincipal;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+
+public class UserPrincipalTest {
+    public static void main(String[] args) {
+        // 권한 리스트 생성 (예: ROLE_USER, ROLE_ADMIN)
+        List<SimpleGrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority("ROLE_USER"),
+                new SimpleGrantedAuthority("ROLE_ADMIN")
+        );
+
+        // UserPrincipal 객체 생성
+        UserPrincipal principal = new UserPrincipal(
+                123L,
+                "testuser@example.com",
+                "mypassword",
+                authorities
+        );
+
+        // 정보 출력
+        System.out.println("ID: " + principal.getId());
+        System.out.println("Username: " + principal.getUsername());
+        System.out.println("Password: " + principal.getPassword());
+        System.out.println("Authorities:");
+        principal.getAuthorities().forEach(auth -> System.out.println(" - " + auth.getAuthority()));
+
+        System.out.println("isAccountNonExpired: " + principal.isAccountNonExpired());
+        System.out.println("isAccountNonLocked: " + principal.isAccountNonLocked());
+        System.out.println("isCredentialsNonExpired: " + principal.isCredentialsNonExpired());
+        System.out.println("isEnabled: " + principal.isEnabled());
+    }
+}

--- a/mylog/src/main/java/mylog_backend/mylog/auth/JwtAuthenticationFilter.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/JwtAuthenticationFilter.java
@@ -10,50 +10,90 @@ import java.io.IOException;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
 
 @RequiredArgsConstructor
+@Slf4j // ⚠️ 로그 추가를 위해 추가
 public class JwtAuthenticationFilter extends GenericFilterBean {
     private final JwtProvider jwtTokenProvider;
     private final RedisTemplate<String, String> redisTemplate;
+
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    private static final String[] SWAGGER_PATHS = {
+            "/auth/**",
+            "/swagger-resources/**",
+            "/webjars/**",
+            "/v3/api-docs/**",
+            "/v3/api-docs",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
+    };
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
 
         HttpServletRequest httpRequest = (HttpServletRequest) request;
-        String path = httpRequest.getRequestURI();
+        String requestURI = httpRequest.getRequestURI();
 
-        // swagger 관련 경로는 필터 패스 (인증 검사 안 함)
-        if (path.startsWith("/v3/api-docs") || path.startsWith("/swagger-ui")) {
-            chain.doFilter(request, response);
-            return;
+        // 스웨거 관련 경로는 필터 패스 (인증 검사 안 함)
+        for (String swaggerPath : SWAGGER_PATHS) {
+            if (pathMatcher.match(swaggerPath, requestURI)) {
+                log.debug("Skipping JWT filter for public path: {}", requestURI); // ⚠️ 로그 추가
+                chain.doFilter(request, response);
+                return; // 필터 체인 중단 후 다음으로 넘김
+            }
         }
 
         // 1. Request Header에서 JWT 토큰 추출
-        String token = resolveToken((HttpServletRequest) request);
-        // 2. validateToken으로 토큰 유효성 검사
-        if (token != null && jwtTokenProvider.validateToken(token)) {
+        String token = resolveToken(httpRequest); // HttpServletRequest로 캐스팅된 변수 사용
 
-            // ✅ 블랙리스트 검사 추가
-            String isLogout = redisTemplate.opsForValue().get(token);
-            if (isLogout != null && isLogout.equals("logout")) {
-                // 로그아웃된 토큰이면 401 Unauthorized 응답 보내고 필터 종료
-                HttpServletResponse httpResponse = (HttpServletResponse) response;
-                httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                return; // 필터 체인 중단
+        // 2. 토큰이 존재하고 유효한지 검사
+        if (token != null) { // ⚠️ 토큰이 null이 아닌 경우에만 유효성 검사 시도
+            if (jwtTokenProvider.validateToken(token)) {
+                // ✅ 블랙리스트 검사 추가
+                String isLogout = redisTemplate.opsForValue().get(token);
+                if (isLogout != null && isLogout.equals("logout")) {
+                    log.warn("Attempt to use blacklisted token: {}", token); // ⚠️ 로그 추가
+                    HttpServletResponse httpResponse = (HttpServletResponse) response;
+                    httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 Unauthorized
+                    httpResponse.getWriter().write("Logout token detected. Please log in again."); // ⚠️ 응답 메시지 추가
+                    return; // 필터 체인 중단
+                }
+
+                // 토큰이 유효하고 블랙리스트에 없으면 Authentication 객체를 SecurityContext에 저장
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+                // ✅ 여기서 principal 타입 확인 로그 추가
+                Object principal = authentication.getPrincipal();
+                log.info("🔍 principal class: {}", principal != null ? principal.getClass().getName() : "null");
+                log.info("🔍 principal value: {}", principal);
+
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.debug("Authentication set for URI: {}", requestURI); // ⚠️ 로그 추가
+
+            } else {
+                // 토큰은 존재하지만 유효하지 않은 경우 (만료, 변조 등)
+                log.warn("Invalid or expired JWT token for URI: {}", requestURI); // ⚠️ 로그 추가
+                // 여기서 굳이 401을 바로 보낼 필요는 없음. Spring Security가 이후 처리 (AuthenticationEntryPoint)
             }
-
-            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-//            chain.doFilter(request, response);
+        } else {
+            // 토큰이 아예 없는 경우 (인증이 필요하지만 토큰이 없는 요청)
+            log.debug("No JWT token found for URI: {}", requestURI); // ⚠️ 로그 추가
+            // 여기서도 굳이 401을 바로 보낼 필요는 없음. Spring Security가 이후 처리 (AuthenticationEntryPoint)
         }
-        // 에러 핸들링 필요
+
+        // 인증 여부와 관계없이 다음 필터 또는 서블릿으로 요청을 넘김
+        // SecurityContextHolder에 Authentication이 설정되어 있으면 인증된 것으로 처리되고,
+        // 없으면 익명(anonymous)으로 처리되거나 인증 실패로 처리됨.
         chain.doFilter(request, response);
     }
 

--- a/mylog/src/main/java/mylog_backend/mylog/auth/JwtProvider.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/JwtProvider.java
@@ -7,29 +7,23 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import java.security.Key;
-import java.util.Arrays;
-import java.util.Collection;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
 
 @Slf4j
 @Component
-//@RequiredArgsConstructor
-
 public class JwtProvider {
+
     private final Key key;
 
     // application.yml에서 secret 값 가져와서 key에 저장
@@ -40,25 +34,26 @@ public class JwtProvider {
 
     // Jwt 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
     public Authentication getAuthentication(String accessToken) {
-        // Jwt 토큰 복호화
         Claims claims = parseClaims(accessToken);
 
-        if (claims.get("auth") == null) {
-            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        if (claims.get("auth") == null || claims.get("id") == null) {
+            throw new RuntimeException("토큰에 필요한 정보가 없습니다.");
         }
 
-        // 클레임에서 권한 정보 가져오기
+        // 권한 정보 가져오기
         Collection<? extends GrantedAuthority> authorities = Arrays.stream(claims.get("auth").toString().split(","))
                 .map(SimpleGrantedAuthority::new)
                 .toList();
 
-        // UserDetails 객체를 만들어서 Authentication return
-        // UserDetails: interface, User: UserDetails를 구현한 class
-        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        // UserPrincipal 생성 (password는 빈 문자열)
+        Long id = Long.parseLong(claims.get("id").toString());
+        String username = claims.getSubject();  // 일반적으로 이메일 또는 유저네임
+
+        UserPrincipal principal = new UserPrincipal(id, username, "", authorities);
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 
-    // 토큰 정보를 검증하는 메서드
+    // 토큰 유효성 검증
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder()
@@ -78,8 +73,7 @@ public class JwtProvider {
         return false;
     }
 
-
-    // accessToken
+    // JWT에서 Claims 추출
     private Claims parseClaims(String accessToken) {
         try {
             return Jwts.parserBuilder()
@@ -88,7 +82,7 @@ public class JwtProvider {
                     .parseClaimsJws(accessToken)
                     .getBody();
         } catch (ExpiredJwtException e) {
-            return e.getClaims();
+            return e.getClaims(); // 만료된 경우에도 claims는 사용
         }
     }
 }

--- a/mylog/src/main/java/mylog_backend/mylog/auth/JwtProvider.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/JwtProvider.java
@@ -45,11 +45,21 @@ public class JwtProvider {
                 .map(SimpleGrantedAuthority::new)
                 .toList();
 
+
         // UserPrincipal 생성 (password는 빈 문자열)
         Long id = Long.parseLong(claims.get("id").toString());
         String username = claims.getSubject();  // 일반적으로 이메일 또는 유저네임
 
         UserPrincipal principal = new UserPrincipal(id, username, "", authorities);
+
+        // "id"를 String으로 꺼내서 Long 변환
+        String idStr = claims.get("id", String.class);
+        Long userId = idStr != null ? Long.valueOf(idStr) : null;
+
+        // UserDetails 객체를 만들어서 Authentication return
+        // UserDetails: interface, User: UserDetails를 구현한 class
+        UserPrincipal userPrincipal = new UserPrincipal(userId, claims.getSubject(), "", authorities);
+
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 

--- a/mylog/src/main/java/mylog_backend/mylog/auth/JwtUtil.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/JwtUtil.java
@@ -80,6 +80,7 @@ public class JwtUtil {
         String accessToken = Jwts.builder()
                 .setSubject(String.valueOf(userId))
                 .claim("auth", authorities)
+                .claim("id", String.valueOf(userId))
                 .setExpiration(accessTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();

--- a/mylog/src/main/java/mylog_backend/mylog/auth/SecurityConfig.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/SecurityConfig.java
@@ -1,9 +1,11 @@
 package mylog_backend.mylog.auth;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -12,7 +14,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import org.springframework.security.config.http.SessionCreationPolicy;
-
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 
 @Configuration
@@ -45,26 +47,26 @@ public class SecurityConfig {
                 // JWT를 사용하기 때문에 세션을 사용하지 않습니다.
                 .sessionManagement(sessionManagement -> sessionManagement
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(authorize -> authorize
-                        // 특정 API에 대해서는 모든 요청을 허가합니다.
-                        // requestMatchers에 여러 인자를 전달할 때 varargs를 사용합니다.
-                        .requestMatchers(
-                                // 회원가입, 로그인 등 인증 없이 허용
-                                "/auth/**",
-                                // Swagger 관련 경로
-                                "/swagger-resources/**",
-                                "/webjars/**",
-                                "/v3/api-docs/**",
-                                "/v3/api-docs",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html"
-                        ).permitAll()
-                        // 그 외 모든 요청에 대해서는 인증을 필요로 합니다.
-                        .anyRequest().authenticated())
-                // JWT 인증을 위하여 직접 구현한 필터를 UsernamePasswordAuthenticationFilter 전에 실행
-                .addFilterBefore(jwtAuthenticationFilter(),
-                        UsernamePasswordAuthenticationFilter.class
-                );
+                .authorizeHttpRequests(authorizeHttpRequests ->
+                        authorizeHttpRequests
+                                // 1. 정적 리소스 (JS, CSS, 이미지 등) 및 webjars (스웨거 UI 리소스 포함) 접근 허용
+                                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                                // 2. 인증/회원가입 등 인증 없이 허용할 API 경로
+                                .requestMatchers("/auth/**").permitAll() // '/auth/'로 시작하는 요청 모두 접근 허가 (기존에 '/api/auth/**'였다면 맞춰주세요)
+                                // 3. OpenApi(Swagger) 문서 경로 명시적 허용 (PathRequest에 포함되지 않는 경우 대비)
+                                .requestMatchers("/v3/api-docs/**").permitAll()
+                                // 4. Swagger UI 관련 경로 명시적 허용
+                                .requestMatchers("/swagger-ui/**").permitAll()
+                                .requestMatchers("/swagger-ui.html").permitAll() // swagger-ui.html 직접 접근 시
+                                // 5. 조회 API는 비로그인 유저도 접근 가능 (예시)
+                                .requestMatchers(HttpMethod.GET, "/api/post/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/posts").permitAll()
+
+                                .anyRequest().authenticated() // 그 외 모든 요청 인증 처리
+                )
+                // JWT 인증을 위한 필터 추가 (UsernamePasswordAuthenticationFilter 이전에 실행)
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 

--- a/mylog/src/main/java/mylog_backend/mylog/config/RedisConfig.java
+++ b/mylog/src/main/java/mylog_backend/mylog/config/RedisConfig.java
@@ -11,10 +11,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    @Value("${SPRING_REDIS_HOST}")
+    @Value("${spring.redis.host:localhost}")
     private String host;
 
-    @Value("${SPRING_REDIS_PORT}")
+    @Value("${spring.redis.port:6379}")
     private int port;
 
     // (선택사항) Redis 비밀번호가 있다면 추가

--- a/mylog/src/main/java/mylog_backend/mylog/config/RedisConfig.java
+++ b/mylog/src/main/java/mylog_backend/mylog/config/RedisConfig.java
@@ -11,10 +11,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.data.redis.host:localhost}")
+    @Value("${SPRING_REDIS_HOST}")
     private String host;
 
-    @Value("${spring.data.redis.port:6379}")
+    @Value("${SPRING_REDIS_PORT}")
     private int port;
 
     // (선택사항) Redis 비밀번호가 있다면 추가

--- a/mylog/src/main/java/mylog_backend/mylog/swagger/SwaggerConfig.java
+++ b/mylog/src/main/java/mylog_backend/mylog/swagger/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package mylog_backend.mylog.swagger;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
@@ -13,21 +14,44 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
-    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+    // JWT 보안 스킴의 이름을 상수로 정의합니다.
+    private static final String JWT_SECURITY_SCHEME_NAME = "bearerAuth"; // 일반적으로 "bearerAuth"를 사용합니다.
 
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
+                // API 전반에 대한 정보를 설정합니다.
                 .info(new Info()
-                        .title("MyLog API")
-                        .version("1.0.0")
-                        .description("MyLog 프로젝트 Swagger 문서"))
-                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
-                .components(new io.swagger.v3.oas.models.Components()
-                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
-                                .name(SECURITY_SCHEME_NAME)
-                                .type(Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")));
+                        .title("MyLog API Test") // API의 제목
+                        .description("MyLog 프로젝트 Swagger UI 연습") // API에 대한 설명
+                        .version("1.0.0")) // API의 버전
+                // JWT 보안 스킴을 컴포넌트에 추가합니다.
+                // 이 스킴은 API 요청에 대한 인증을 정의하며, 스웨거 UI에서 'Authorize' 버튼을 통해 사용됩니다.
+                .components(new Components()
+                        .addSecuritySchemes(JWT_SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .name(JWT_SECURITY_SCHEME_NAME) // 스킴의 이름 (Swagger UI에 표시될 이름)
+                                .type(SecurityScheme.Type.HTTP) // HTTP 기반 인증
+                                .scheme("bearer") // 인증 스킴 (Bearer Token)
+                                .bearerFormat("JWT"))) // 토큰 형식
+                // 모든 API 엔드포인트에 이 JWT 보안 스킴을 적용하도록 설정합니다.
+                // 이는 스웨거 UI에서 'Authorize' 버튼이 활성화되고,
+                // 이 스킴을 통해 전송되는 요청에 JWT 토큰이 포함되도록 합니다.
+                // 이 설정은 API 정의 자체의 접근과는 무관합니다.
+                .addSecurityItem(new SecurityRequirement().addList(JWT_SECURITY_SCHEME_NAME));
     }
 }
+
+
+//                .info(new Info()
+//                        .title("MyLog API")
+//                        .version("1.0.0")
+//                        .description("MyLog 프로젝트 Swagger 문서"))
+//                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+//                .components(new io.swagger.v3.oas.models.Components()
+//                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+//                                .name(SECURITY_SCHEME_NAME)
+//                                .type(Type.HTTP)
+//                                .scheme("bearer")
+//                                .bearerFormat("JWT")));
+//    }
+//}

--- a/mylog/src/test/java/mylog_backend/mylog/config/EmbeddedRedisConfig.java
+++ b/mylog/src/test/java/mylog_backend/mylog/config/EmbeddedRedisConfig.java
@@ -14,7 +14,7 @@ public class EmbeddedRedisConfig {
 
     @PostConstruct
     public void startRedis() throws IOException {
-        redisServer = new RedisServer(6379);
+        redisServer = new RedisServer(6380);
         redisServer.start();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#31 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. 테스트용 임베디드 레디스와 컨테이너용 레디스의 포트를 달리 설정
springboot 컨테이너 로그를 보니 레디스가 빈으로 생성되지 않음을 확인. 하지만 레디스 컨테이너는 잘 띄워졌음. 
알고보니 테스트용 레디스와 개발용 레디스끼리 포트 충돌이 일어나 NPE를 일으킨 것
테스트용 레디스는 6780에, 개발용 레디스는 6779?에 매핑

2. 메모, 일기 생성 API 테스트시 500 코드가 뜨는 것을 해결
UserPrincipal, AccessToken은 잘 생성됨을 확인
JWT io에서 토큰을 확인해보니 payload에 userId를 넘겨주지 않았음.
따라서 payload에 추가로 userId를 넘겨주도록 JwtProvider 수정




### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
