### PR TITLE
fix/#33 : 선호태그저장 로직 수정

### DIFF
--- a/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceController.java
+++ b/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceController.java
@@ -27,13 +27,13 @@ public class PreferenceController {
      */
     @Operation(summary = "선호 태그 입력",description = "사용자 선호 태그를 받아낸다.")
     @PostMapping("/preferences")
-    public ResponseEntity<Void> savePreferences(@RequestBody PreferenceRequest request,
+    public ResponseEntity<PreferenceResponse> savePreferences(@RequestBody PreferenceRequest request,
                                                 @AuthenticationPrincipal UserPrincipal userPrincipal) {
         // 인증된 사용자의 id를 할당
         Long userId = userPrincipal.getId();
 
         // 아이디와 요청을 이용하여 선호 태그 저장 메서드 호출
-        preferenceService.savePreferences(userId, request);
-        return ResponseEntity.ok().build();
+        PreferenceResponse response =  preferenceService.savePreferences(userId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceResponse.java
@@ -24,15 +24,11 @@ public class PreferenceResponse {
     /**
      * 태그를 성공적으로 입력시 사용
      * @param message : 성공 메시지
-     * @param preferenceId1 : 선호태그1번의 아이디
-     * @param preferenceId2 : 선호태그2번의 아이디
      * @return : of 정적 메서드로 응답 변환
      */
-    public static PreferenceResponse of(String message, Integer preferenceId1, Integer preferenceId2) {
+    public static PreferenceResponse of(String message) {
         return PreferenceResponse.builder()
                 .message(message)
-                .preferenceId1(preferenceId1)
-                .preferenceId2(preferenceId2)
                 .build();
     }
 

--- a/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceService.java
+++ b/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import mylog_backend.mylog.user.User;
 import mylog_backend.mylog.user.UserRepository;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +24,7 @@ public class PreferenceService {
      * @param request : 사용자가 선호 태그를 입력했을때 가공하는 DTO
      */
     @Transactional // User 엔티티 지연로딩 해결
-    public void savePreferences(Long userId, PreferenceRequest request) {
+    public PreferenceResponse savePreferences(Long userId, PreferenceRequest request) {
         // DB에 저장된 사용자를 가져옴
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("사용자 엔티티를 찾을 수 없습니다."));
@@ -33,6 +34,8 @@ public class PreferenceService {
         List<Preference> preferences = request.toPreferences(user);
 
         preferenceRepository.saveAll(preferences);
+
+        return PreferenceResponse.of("선호 태그가 저장되었습니다.");
 
     }
 }


### PR DESCRIPTION
- 요청 성공시 응답으로 성공 메시지를 날리도록 수정

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#34 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
요청 성공시 응답으로 메시지를 날리도록 수정함.
1. 서비스 메서드 수정
- 응답 DTO의 of메서드를 이용해 메시지를 반환함.

2. 컨트롤러 수정
- response에 선호 태그 저장 메서드가 반환하는 값을 할당함.
- 여기서 반환값은 앞서 말한, of메서드로 만든 성공 메시지

3. 응답 바디의 내용을 축소
기존에 메시지 외에 선호 태그의 아이디까지 반환했지만, 그럴 필요성이 없는듯하여 제거


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
