### PR TITLE
fix/#33 : 메모, 선호태그 응답 DTO 수정

### DIFF
--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
@@ -1,10 +1,12 @@
 package mylog_backend.mylog.memo;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+@JsonInclude(JsonInclude.Include.NON_NULL) // response body에서 null값인 필드는 제외됨
 @Schema(description = "메모 관련 요청 처리후 결과물을 담는 응답 DTO입니다.")
 @Getter
 public class MemoResponse {

--- a/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/preference/PreferenceResponse.java
@@ -1,8 +1,10 @@
 package mylog_backend.mylog.preference;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "사용자 선호 응답 DTO")
 public class PreferenceResponse {
 


### PR DESCRIPTION
- @JsonInclude(JsonInclude.Include.NON_NULL)를 추가해 response body 구성시 NULL인 필드는 제외되어 반환됨

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#36 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- @JsonInclude(JsonInclude.Include.NON_NULL)를 추가해 response body 구성시 NULL인 필드는 제외되어 반환됨


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
