### PR TITLE
dev-ops/#52 : grafana + prometheus 설정

### DIFF
--- a/mylog/build.gradle
+++ b/mylog/build.gradle
@@ -65,18 +65,17 @@ dependencies {
 	// Java에서 JSON 파싱 및 생성에 사용
 	implementation 'org.json:json:20231013'
 
+
 	// Embedded redis 라이브러리
 	testImplementation('com.github.codemonstur:embedded-redis:1.4.3') {
 		exclude group: 'org.slf4j', module: 'slf4j-simple'
 	}
 
-	// 전체 프로젝트에서 충돌 나는 로깅 라이브러리 제외 (이중 체크)
-//	configurations {
-//		all {
-//			exclude group: 'org.slf4j', module: 'slf4j-simple'
-//			exclude group: 'commons-logging', module: 'commons-logging'
-//		}
-//	}
+
+	// 모니터링 도구 prometheus + grafana 조합을 위한 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 
 
 	testImplementation 'org.mockito:mockito-core'

--- a/mylog/docker-compose.yml
+++ b/mylog/docker-compose.yml
@@ -5,7 +5,7 @@ services:
 #    build: . # 배포시 이미 빌드된 이미지를 가져오므로 삭제
     container_name: mylog-springboot
     ports:
-      - "8080:8080"
+      - "18080:8080" # 서버 외부 포트를 18080으로 설정
     depends_on:
       postgres:
         condition: service_healthy # postgres가 켜질때까지 기다림
@@ -25,6 +25,8 @@ services:
       - SPRING_REDIS_PORT=6379
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - YOUTUBE_API_KEY=${YOUTUBE_API_KEY}
+    networks:
+      - mylog_app-network
 
 
   postgres:
@@ -43,6 +45,9 @@ services:
       interval: 10s # 상태를 확인하는 주기
       timeout: 5s # 확인했을때 5초간 응답이 없으면 실패했다고 판단
       retries: 5 # 최대 시도 횟수
+    networks:
+      - mylog_app-network
+
 
 
   rabbitmq:
@@ -59,6 +64,9 @@ services:
       timeout: 5s
       retries: 10
       start_period: 10s
+    networks:
+      - mylog_app-network
+
 
 
   redis:
@@ -72,12 +80,44 @@ services:
       timeout: 3s
       retries: 10
       start_period: 10s
+    networks:
+      - mylog_app-network
+
 
 
   # prometheus, grafana 설정시 추가
-#  prometheus:
+  prometheus:
+    image: "prom/prometheus:v2.53.4"
+    container_name: mylog-prometheus
+    ports:
+      - "19090:9090" # http://localhost:19090/
+    volumes:
+      - ./src/main/java/mylog_backend/mylog/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    command: # prometheus.yml의 설정대로 실행
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    networks:
+      - mylog_app-network
 
 
+  grafana:
+    image: "grafana/grafana:12.0.1"
+    container_name: mylog-grafana
+    volumes: # src/main 내 프로젝트 폴더에 위치
+      - ./src/main/java/mylog_backend/mylog/grafana:/etc/grafana/provisioning
+      - ./src/main/java/mylog_backend/mylog/grafana/data:/var/lib/grafana
+    ports:
+      - "13000:3000"
+    networks:
+      - mylog_app-network
+
+
+
+
+# 다른 컨테이너끼리 이름으로 통신 가능
+networks:
+  mylog_app-network:
+    name: mylog_app-network
+    driver: bridge
 
 volumes:
   postgres_data:

--- a/mylog/src/main/java/mylog_backend/mylog/auth/JwtAuthenticationFilter.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/JwtAuthenticationFilter.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
-    private static final String[] SWAGGER_PATHS = {
+    private static final String[] AGREE_PATHS = {
             "/auth/signup",
             "/auth/login",
             "/swagger-resources/**",
@@ -34,7 +34,12 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             "/v3/api-docs/**",
             "/v3/api-docs",
             "/swagger-ui/**",
-            "/swagger-ui.html"
+            "/swagger-ui.html",
+            "/actuator/**",
+            "/prometheus/**",
+            "/grafana/**",
+            "/api/metrics/**",
+            "metrics"
     };
 
     @Override
@@ -44,9 +49,9 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         String requestURI = httpRequest.getRequestURI();
 
-        // 스웨거 관련 경로는 필터 패스 (인증 검사 안 함)
-        for (String swaggerPath : SWAGGER_PATHS) {
-            if (pathMatcher.match(swaggerPath, requestURI)) {
+        // 스웨거, 모니터링, 인증 관련 경로는 필터 패스 (인증 검사 안 함)
+        for (String agreePath : AGREE_PATHS) {
+            if (pathMatcher.match(agreePath, requestURI)) {
                 log.debug("Skipping JWT filter for public path: {}", requestURI); // ⚠️ 로그 추가
                 chain.doFilter(request, response);
                 return; // 필터 체인 중단 후 다음으로 넘김

--- a/mylog/src/main/java/mylog_backend/mylog/auth/SecurityConfig.java
+++ b/mylog/src/main/java/mylog_backend/mylog/auth/SecurityConfig.java
@@ -61,6 +61,17 @@ public class SecurityConfig {
                                 // 5. 조회 API는 비로그인 유저도 접근 가능 (예시)
                                 .requestMatchers(HttpMethod.GET, "/api/post/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/posts").permitAll()
+                                // 6. 모니터링 도구 관련 경로는 패스 가능
+                                .requestMatchers("/actuator/**").permitAll()
+                                .requestMatchers( "/prometheus/**").permitAll()
+                                .requestMatchers("/grafana/**").permitAll()
+                                .requestMatchers("/api/metrics/**").permitAll()
+                                .requestMatchers("metrics").permitAll()
+
+
+
+
+
 
                                 .anyRequest().authenticated() // 그 외 모든 요청 인증 처리
                 )

--- a/mylog/src/main/java/mylog_backend/mylog/prometheus/prometheus.yml
+++ b/mylog/src/main/java/mylog_backend/mylog/prometheus/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s         # 메트릭 기본 수집 주기
+  evaluation_interval: 15s     # 메트릭 평가 주기
+
+scrape_configs:                # 메트릭을 가져올 대상 목록
+  - job_name: 'mylog-app-data'     # 스프링 부트 애플리케이션의 데이터 수집
+    metrics_path: '/actuator/prometheus'  # 메트릭 노출 경로 (Spring Boot Actuator + Micrometer 사용)
+    static_configs:
+      - targets: ['mylog-springboot:8080']      # 메트릭 수집할 대상 (컨테이너 이름 or IP:port)
+
+  - job_name: 'mylog-prometheus' # 프로메데우스 메트릭 수집
+    metrics_path: "/metrics" # 프로메데우스의 기본 수집 경로
+    static_configs:
+      - targets: [ 'mylog-prometheus:9090' ] # 프로메데우스의 컨테이너와 포트 명시


### PR DESCRIPTION
- docker-compose.yml에 그라파나, 프로메데우스 컨테이너 설정
- 프로메데우스가 로컬호스트로 접속됨을 확인
- 그라파나로 대시보드 설정

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#52 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- docker-compose.yml에 그라파나, 프로메데우스 컨테이너 설정
- 프로메데우스가 로컬호스트로 접속됨을 확인
- 그라파나로 대시보드 설정
- 도커 컨테이너간에 네트워크 설정
- 모니터링 도구를 위해 의존성 추가


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
