### PR TITLE
refactor/#54 : Diary 코드 리팩토링

### DIFF
--- a/mylog/src/main/java/mylog_backend/mylog/diary/Diary.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/Diary.java
@@ -7,11 +7,11 @@ import lombok.*;
 import mylog_backend.mylog.common.domain.DateEntity;
 import mylog_backend.mylog.user.User;
 
-@Entity
+@Entity // JPA 사용
 @Getter
-@Builder
+@Builder // 생성자에 빌더패턴 적용
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 하이버네이트가 Diary 객체를 리플렉션 방식으로 사용하도록 기본 생성자를 Protected 허용
 @Table(name = "diary")
 public class Diary extends DateEntity {
 
@@ -19,33 +19,39 @@ public class Diary extends DateEntity {
     @Id
     private Long id;
 
-    @Lob
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, length = 100)
     private String dairyTitle;
 
     @Lob
     @Column(nullable = false, columnDefinition = "TEXT")
     private String dairyContent;
 
-    @Column(nullable = true, columnDefinition = "VARCHAR(10)")
-    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    @Enumerated(EnumType.STRING) // DB에 저장시 String(varchar)타입으로 저장됨
     private Feeling feeling;
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    @Column(nullable = false, length = 10)
     @Enumerated(EnumType.STRING)
     @Builder.Default
-    private IsPublic isPublic = IsPublic.PRIVATE;
+    private IsPublic isPublic = IsPublic.PRIVATE; // 기본값이 PRIVATE
 
-    @Column(nullable = true)
+    @Column(nullable = false)
     @Builder.Default
-    @Min(value = 0, message = "점수는 0 이상이여야 합니다.")
+    @Min(value = 0, message = "점수는 0 이상이여야 합니다.") // 점수는 0 ~ 100점 사잇값
     @Max(value = 100, message = "점수는 100 이하여야 합니다.")
-    private Integer feelingScore = 0;
+    private Integer feelingScore = 0; // 감정과 감정점수를 입력하지 않았을때 기본값은 0
 
 
-    // created_at, modified_at 필드는 DateEntity에 존재
+    // created_at, modified_at 필드는 DateEntity에 존재하고, Auditing 기능을 통해 관리
 
-//     생성자
+    /**
+     * Diary 생성자
+     * @param dairyTitle : 일기 제목
+     * @param dairyContent : 일기 내용
+     * @param feeling : 감정 상태
+     * @param feelingScore : 감정 점수
+     * @param isPublic : 공개 여부
+     */
     public Diary(String dairyTitle, String dairyContent, Feeling feeling, Integer feelingScore, IsPublic isPublic) {
         this.dairyTitle = dairyTitle;
         this.dairyContent = dairyContent;

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryController.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryController.java
@@ -19,10 +19,11 @@ public class DiaryController {
     private final DiaryService diaryService;
 
     /**
-     * 일기 생성
-     * @param request
-     * @return
+     * @param request : 일기 요청 DTO
+     * @param userPrincipal : 인증된 유저를 담는 객체
+     * @return : 응답(메시지 + 저장된 일기 아이디)와 201 상태크도 반환
      */
+
     @Operation(summary = "일기 생성", description = "일기를 생성합니다.")
     @PostMapping("/diaries")
     public ResponseEntity<DiaryResponse> createDiary(@RequestBody DiaryRequest request, @AuthenticationPrincipal UserPrincipal userPrincipal) {
@@ -33,6 +34,11 @@ public class DiaryController {
     }
 
 
+    /**
+     *
+     * @param userPrincipal : 인증된 유저를 담는 객체
+     * @return : 조회된 일기 목록들을 반환
+     */
     @Operation(summary = "일기 목록 조회")
     @GetMapping("/diaries")
     public ResponseEntity<List<DiaryResponse>> getDiaries(@AuthenticationPrincipal UserPrincipal userPrincipal) {
@@ -43,6 +49,12 @@ public class DiaryController {
     }
 
 
+    /**
+     *
+     * @param diaryId : 일기 아이디
+     * @param userPrincipal : 인증된 유저를 담는 객체
+     * @return : 조회된 일기 하나를 반환
+     */
     @Operation(summary = "단일 일기 조회")
     @GetMapping("/diaries/{diaryId}")
     public ResponseEntity<DiaryResponse> getDiary(@PathVariable Long diaryId, @AuthenticationPrincipal UserPrincipal userPrincipal) {

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRepository.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRepository.java
@@ -14,12 +14,8 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
      * @return
      */
     List<Diary> findAllByUserId(Long userId);
+    // spring data jpa가 명명한 네이밍 룰에 의해 쿼리 메서드 기능이 작동
+    // 위 메서드는 다음 쿼리문과 같은 기능을 한다.
+    // SELECT d FROM Diary d WHERE d.user.id = :userId
 
-
-    /**
-     * 유저 아이디를 기준으로 단일 일기 조회
-     * @param userId
-     * @return
-     */
-    Diary findByUserId(Long userId);
 }

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRequest.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryRequest.java
@@ -6,9 +6,6 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import mylog_backend.mylog.memo.Memo;
-import org.hibernate.sql.model.jdbc.MergeOperation;
 
 @Schema(description = "일기 요청 DTO")
 @Getter
@@ -38,16 +35,16 @@ public class DiaryRequest {
 
     /**
      * 일기 요청 DTO 생성자
-     * @param diaryTitle
-     * @param diaryContent
-     * @param feeling
-     * @param feelingScore
-     * @param isPublic
+     * @param diaryTitle : 일기 제목
+     * @param diaryContent : 일기 내용
+     * @param feeling : 감정
+     * @param feelingScore : 감정 점수
+     * @param isPublic : 공개 여부
      */
     @Builder
     public DiaryRequest(String diaryTitle, String diaryContent, Feeling feeling, Integer feelingScore, IsPublic isPublic) {
-        this.diaryContent = diaryContent;
         this.diaryTitle = diaryTitle;
+        this.diaryContent = diaryContent;
         this.feeling = feeling;
         this.isPublic = isPublic;
         this.feelingScore = feelingScore;
@@ -56,9 +53,9 @@ public class DiaryRequest {
     /**
      * 일기 생성시 사용되는 변환 메서드
      * 일기 내용 입력후 생성 요청 -> from()메서드로 변환 -> 비즈니스 로직 수행
-     * @return
+     * @return : 가공된 일기 엔티티
      */
-    public Diary from() {
+    public Diary toDiary() {
         return Diary.builder()
                 .dairyContent(diaryContent)
                 .dairyTitle(diaryTitle)

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryResponse.java
@@ -38,8 +38,8 @@ public class DiaryResponse {
      * 일기 응답 DTO 생성자
      * 일기 관련 로직후 이용됨
      * 로직이 다양해질수록 확장성을 띄도록 설계
-     * @param message
-     * @param diaryId
+     * @param message : 일기 요청 성공시 메시지
+     * @param diaryId : 일기 아이디
      */
     @Builder
     public DiaryResponse(String message, Long diaryId, String dairyTitle,
@@ -52,20 +52,19 @@ public class DiaryResponse {
         this.isPublic = isPublic;
         this.feeling = feeling;
         this.feelingScore = feelingScore;
-        // 이후 응답DTO가 사용되는 형태에 따라서 필드 추가 가능
     }
 
 
     /**
      * 일기 단건/목록 조회시 사용
-     * @param message
-     * @param diaryId
-     * @param dairyTitle
-     * @param dairyContent
-     * @param feeling
-     * @param isPublic
-     * @param feelingScore
-     * @return
+     * @param message : 일기 조회 요청 성공시 메시지
+     * @param diaryId : 일기 아이디
+     * @param dairyTitle : 일기 제목
+     * @param dairyContent : 일기 내용
+     * @param feeling : 감정
+     * @param isPublic : 공개여부
+     * @param feelingScore : 감정점수
+     * @return : 일기 응답 DTO로 가공된 데이터
      */
     public static DiaryResponse toDiary(String message, Long diaryId, String dairyTitle,
                                         String dairyContent, Feeling feeling,

--- a/mylog/src/main/java/mylog_backend/mylog/diary/DiaryService.java
+++ b/mylog/src/main/java/mylog_backend/mylog/diary/DiaryService.java
@@ -1,16 +1,14 @@
 package mylog_backend.mylog.diary;
 
 import lombok.RequiredArgsConstructor;
+import mylog_backend.mylog.common.exception.UnauthorizedException;
 import mylog_backend.mylog.common.exception.UserNotFoundException;
-import mylog_backend.mylog.memo.MemoResponse;
 import mylog_backend.mylog.user.User;
 import mylog_backend.mylog.user.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -20,36 +18,58 @@ public class DiaryService {
     private final UserRepository userRepository;
 
     /**
-     * 1. 일기 생성 메서드
+     * 1. 일기 생성
      * @param userId : 유저 아이디
-     * @param request : 프론트에게 일기에 대한 내용을 입력받음
-     * @return : 응답을 가공하여 반환
+     * @param request : 프론트엔드에게 일기에 대한 내용을 입력받음
+     * @return : 응답 성공 메시지, 저장된 일기 아이디 반환
      */
-    @Transactional
-    public DiaryResponse createDiary(Long userId , @RequestBody DiaryRequest request) {
+    @Transactional // 해당 기능은 한 트랜잭션에서 작용
+    public DiaryResponse createDiary(Long userId , DiaryRequest request) { // userId로 사용자의 일기를 구분
+        // 사용자를 Id로 찾아옴
         User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
-        Diary diary = request.from();
+        // 요청 DTO로 입력된 내용을 일기 엔티티로 가공
+        Diary diary = request.toDiary();
 
+        // 일기 레포지토리에 저장 전 사용자와 관계를 맺어줌
         user.addDiary(diary);
 
+        // 일기를 레포지토리에 저장, 저장된 일기를 할당받음
         Diary savedDiary = diaryRepository.save(diary);
 
+        // 성공 메시지와 함께 저장된 일기 아이디를 반환
         return DiaryResponse.of("일기가 성공적으로 생성되었습니다.", savedDiary.getId());
     }
 
 
     /**
      * 2. 일기 목록 조회 메서드
-     * @param userId
-     * @return
+     * @param userId : 사용자 아이디
+     * @return : 사용자 아이디로 가져온 모든 일기들을 stream 객체로 가공해 반환
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<DiaryResponse> getDiaries(Long userId) {
+        // 인증된 사용자인지 판단
         User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
 
-        return diaryRepository.findAllByUserId(userId)
-                .stream()
-                .map(diary -> DiaryResponse.toDiary(
+        // 해당 유저가 작성한 일기를 모두 조회
+        List<Diary> diaries = diaryRepository.findAllByUserId(userId);
+
+        // 일기 필터링
+        List<Diary> filteredDiaries = diaries.stream()
+                .filter(diary -> {
+                    Long diaryWriterId = diary.getUser().getId(); // 작성자 아이디를 추출
+                    if (userId.equals(diaryWriterId)) { // 작성자 아이디와 userId가 맞다면 true
+                        return true;
+                    }
+                    else { // 작성자와 userId가 다르다면 PUBLIC으로 공개된 일기만 가져옴
+                        return diary.getIsPublic() == IsPublic.PUBLIC;
+                    }
+                })
+                .toList();
+
+        return filteredDiaries
+                .stream() // 조회된 일기들을 stream 객체로 가공
+                .map(diary ->  DiaryResponse.toDiary( // 조회된 diary들을 응답 DTO의 toDiary 형태에 맞게 매핑
                         "일기 목록 조회 성공",
                         diary.getId(),
                         diary.getDairyTitle(),
@@ -57,32 +77,38 @@ public class DiaryService {
                         diary.getFeeling(),
                         diary.getIsPublic(),
                         diary.getFeelingScore()))
-                .collect(Collectors.toList());
+                .toList(); // 매핑된 DTO들을 다시 List로 가공
     }
 
 
     /**
      * 3. 일기 단건 조회 메서드
-     * @param userId
-     * @param diaryId
-     * @return
+     * @param userId : 요청한 사용자 아이디
+     * @param diaryId : 조회하려는 일기 아이디
+     * @return : 일기 단건을 반환
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public DiaryResponse getDiary(Long userId, Long diaryId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
 
         Diary diary = diaryRepository.findById(diaryId)
-                .orElseThrow(()-> new IllegalArgumentException("메모를 찾을 수 없습니다."));
+                .orElseThrow(()-> new IllegalArgumentException("일기를 찾을 수 없습니다."));
 
-        return DiaryResponse.builder()
-                .message("단일 일기 조회 성공")
-                .diaryId(diary.getId())
-                .dairyTitle(diary.getDairyTitle())
-                .dairyContent(diary.getDairyContent())
-                .feeling(diary.getFeeling())
-                .feelingScore(diary.getFeelingScore())
-                .isPublic(diary.getIsPublic())
-                .build();
+        // 일기 작성자와 맞는지 판단하는 로직
+        if (diary.getIsPublic() == IsPublic.PRIVATE) { // 공개여부가 PRIVATE 일때 작성자만 조회 가능
+            if (!diary.getUser().getId().equals(userId)) { // 일기 작성자의 아이디가 userId와 일치하지 않을때 예외 발생
+                throw new UnauthorizedException("해당 일기를 조회할 권한이 없습니다.");
+            }
+        }
+
+        return DiaryResponse.toDiary(
+                "단일 일기 조회 성공",
+                diary.getId(),
+                diary.getDairyTitle(),
+                diary.getDairyContent(),
+                diary.getFeeling(),
+                diary.getIsPublic(),
+                diary.getFeelingScore());
 
     }
 

--- a/mylog/src/test/java/mylog_backend/mylog/diary/DiaryServiceIntegrationTest.java
+++ b/mylog/src/test/java/mylog_backend/mylog/diary/DiaryServiceIntegrationTest.java
@@ -1,7 +1,7 @@
 package mylog_backend.mylog.diary;
 
 import jakarta.validation.ConstraintViolationException;
-import lombok.RequiredArgsConstructor;
+import mylog_backend.mylog.common.exception.UnauthorizedException;
 import mylog_backend.mylog.user.User;
 import mylog_backend.mylog.user.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -12,20 +12,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import static org.assertj.core.api.Assertions.as;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class DiaryServiceTest {
+public class DiaryServiceIntegrationTest {
 
+    // 통합 테스트를 위해 실제 구현체들을 주입받아 사용
     @Autowired private DiaryService diaryService;
     @Autowired private DiaryRepository diaryRepository;
     @Autowired private UserRepository userRepository;
 
-
+    // 테스트용 데이터 생성
     protected User testUser;
+    protected User daiseek;
     protected DiaryRequest request1;
     protected DiaryRequest request2;
     protected DiaryResponse response1;
@@ -34,6 +37,7 @@ public class DiaryServiceTest {
 
     @BeforeEach
     void setUp() {
+        // 1. 유저 생성
         testUser = User.builder()
                 .loginId("testId1234")
                 .email("test@example.com")
@@ -42,6 +46,15 @@ public class DiaryServiceTest {
                 .build();
         userRepository.save(testUser);
 
+        daiseek = User.builder()
+                .loginId("daiseek123")
+                .email("daiseek@example.com")
+                .password("daiseek123")
+                .userName("정대식")
+                .build();
+        userRepository.save(daiseek);
+
+        // 2. 일기1 생성
         DiaryRequest request1 = DiaryRequest.builder()
                 .diaryTitle("테스트일기1")
                 .diaryContent("엄마저는잘지내요테커사람들이코딩을잘가르쳐줘요")
@@ -51,6 +64,7 @@ public class DiaryServiceTest {
                 .build();
         response1 = diaryService.createDiary(testUser.getId(), request1);
 
+        // 일기2 생성
         DiaryRequest request2 = DiaryRequest.builder()
                 .diaryTitle("테스트일기2")
                 .diaryContent("안녕하세요?")
@@ -80,8 +94,8 @@ public class DiaryServiceTest {
                 .diaryTitle("테스트일기")
                 .diaryContent("엄마저는잘지내요테커사람들이코딩을잘가르쳐줘요")
                 .feeling(Feeling.SAD)
-                .feelingScore(30)
                 .isPublic(IsPublic.PRIVATE)
+                .feelingScore(30)
                 .build();
 
         // when
@@ -154,6 +168,30 @@ public class DiaryServiceTest {
         assertThat(testResponse.getFeelingScore()).isEqualTo(50);
 
         assertThat(savedDiary.getUser().getId()).isEqualTo(testUser.getId());
+
+    }
+
+
+    @Test
+    @DisplayName("PRIVATE로 설정된 일기는 타인이 조회할 수 없다.")
+    void getOtherDiary() {
+        // given
+
+        // testUser의 비공개된 일기
+        Diary testUserDiary1 = diaryRepository.findById(response1.getDiaryId())
+                .orElseThrow(() -> new IllegalArgumentException("일기를 찾을 수 없습니다."));
+
+        // testUser의 공개된 일기
+        Diary testUserDiary2 = diaryRepository.findById(response2.getDiaryId())
+                .orElseThrow(() -> new IllegalArgumentException("일기를 찾을 수 없습니다."));
+
+
+        // when & then
+        // daiseek가 testUser의 비공개 일기(response2)를 조회 시도하면 예외가 발생해야 한다.
+        assertThrows(UnauthorizedException.class, () -> {
+            diaryService.getDiary(daiseek.getId(), testUserDiary1.getId());
+        });
+
 
     }
 


### PR DESCRIPTION
- columnDefinition -> length로 속성 변경
- 주석 문서화를 상세하게 변경
- DiaryRepository에서 사용하지 않은 메서드 제거
- 응답 DTO에서 from() -> toEntity()로 변경
- 일기 조회시 PUBLIC, PRIVATE의 경우에 따라서 조회할 수 있도록 로직 설계
- 접근 권한 관련 테스트 추가

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#54 

## 📝작업 내용
- columnDefinition -> length로 속성 변경
- 주석 문서화를 상세하게 변경
- DiaryRepository에서 사용하지 않은 메서드 제거
- 응답 DTO에서 from() -> toEntity()로 변경
- 일기 조회시 PUBLIC, PRIVATE의 경우에 따라서 조회할 수 있도록 로직 설계
- 접근 권한 관련 테스트 추가


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
