### PR TITLE
refactor/#57 : Memo 코드 리팩토링

### DIFF
--- a/mylog/src/main/java/mylog_backend/mylog/memo/Memo.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/Memo.java
@@ -23,14 +23,14 @@ public class Memo extends DateEntity {
     private String memoContent;
 
     @Enumerated(EnumType.STRING) // ENUM 타입을 String으로 지정
-    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    @Column(nullable = false, length = 10)
     @Builder.Default
     private IsChecked isChecked = IsChecked.UNCHECKED; // 기본값 설정
 
     // modifiedAt, CreatedAt 필드는 DataEntity에 존재
     // 0: 논리적 삭제, 1: 공개
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    @Column(nullable = false, length = 10)
     @Builder.Default
     private IsVisible isVisible = IsVisible.VISIBLE;
 

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoController.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoController.java
@@ -19,36 +19,44 @@ public class MemoController {
     private final MemoService memoService;
 
     /**
-     * 메모 생성
+     * 메모 생성 메서드
      * @param request : 메모 요청 DTO
-     * @return
+     * @param userPrincipal : 인증된 사용자를 담는 객체
+     * @return : 성공적으로 생성시 응답과 함께 201 상태코드 반환
      */
     @Operation(summary = "메모 생성", description = "새 메모를 생성합니다.")
     @PostMapping("/memos")
     public ResponseEntity<MemoResponse> createMemo(@RequestBody MemoRequest request, @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
-        // 사용자의 아이디를 가져옴
+        // 1. 사용자의 아이디를 가져옴
         Long userId = userPrincipal.getId();
 
+        // 2. 메모 서비스에서 메모 생성 메서드의 결과물을 response를 할당
         MemoResponse response = memoService.createMemo(userId, request); // 사용자 id가 추가됨
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
 
     /**
-     * 메모 제거 기능
+     * 메모 체크시 논리적 삭제가 이루어지는 기능
+     * @param memoId : 체크표시 요청된 메모
+     * @param userPrincipal : 인증된 사용자를 담는 객체
+     * @return : 성공시 응답과 함께 200 상태 코드 반환
      */
     @Operation(summary = "메모 확인 표시", description = "메모를 체크했을때 논리적 삭제가 이루어집니다.")
     @PatchMapping("/memos/{memoId}")
     public ResponseEntity<MemoResponse> checkedMemo(@PathVariable Long memoId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        // 1. userPrincipal에서 사용자 아이디를 할당
         Long userId = userPrincipal.getId();
 
+        // 2. 서비스의 메서드를 이용해 메모 체크 로직 수행
         MemoResponse response = memoService.checkedMemo(userId, memoId);
         return ResponseEntity.ok(response);
     }
 
     /**
      * 메모 목록 조회 기능
+     * @param userPrincipal : 인증된 사용자를 담는 객체
      */
     @Operation(summary = "메모 목록 조회", description = "체크되지 않은 메모들을 불러옵니다.")
     @GetMapping("/memos")
@@ -61,11 +69,15 @@ public class MemoController {
 
     /**
      * 단일 메모 조회 기능
+     * @param memoId : 체크표시 요청된 메모
+     * @param userPrincipal : 인증된 사용자를 담는 객체
      */
     @Operation(summary = "단일 메모 조회", description = "메모를 하나씩 조회합니다.")
     @GetMapping("/memos/{memoId}")
     public ResponseEntity<MemoResponse> getMemo(@PathVariable Long memoId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        MemoResponse response = memoService.getMemo(userPrincipal.getId(), memoId);
+        Long userId = userPrincipal.getId();
+
+        MemoResponse response = memoService.getMemo(userId, memoId);
         return ResponseEntity.ok(response);
     }
 

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoRepository.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoRepository.java
@@ -5,16 +5,16 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-// JpaRepository를 상속받는 MemoRepository 생성
+// JpaRepository 상속받는 MemoRepository 생성
 // 자동으로 구현체가 만들어져 MemoRepository 구현체가 사용됨
 @Repository
 public interface MemoRepository extends JpaRepository<Memo, Long> {
 
     /**
-     * isVisible = VISIBLE인 메모만 필터링
+     * isVisible = VISIBLE 메모만 필터링
      * 메모를 생성한 유저가 맞는지 판별하기 위해 매개변수 추가
-     * @param isVisible
-     * @return
+     * @param isVisible : 보이는지 여부
+     * @return : VISIBLE 메모를 모두 가져옴
      */
     List<Memo> findByUserIdAndIsVisible(Long userId, IsVisible isVisible);
 

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoRequest.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoRequest.java
@@ -27,11 +27,12 @@ public class MemoRequest {
     // url별로 메모에 대한 매개변수가 필요할때 확장가능
     public MemoRequest(String memoContent, IsChecked isChecked, byte isVisible) {
         this.memoContent = memoContent;
+
     }
 
     // 메모 객체 생성 메서드
     // 메모 생성자에서 컨텐트만 가져와서 세팅
-    public Memo from() {
+    public Memo toMemo() {
         return Memo.builder()
                 .memoContent(memoContent)
                 .isChecked(IsChecked.UNCHECKED)

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoResponse.java
@@ -52,7 +52,13 @@ public class MemoResponse {
     }
 
 
-    // 메모 체크시 제거 응답 DTO 메서드
+    /**
+     * 메모 체크시 논리적 삭제가 이루어짐
+     * @param message : 성공시 응답 메시지
+     * @param memoId : 체크된 메모 아이디
+     * @param isChecked : CHECKED 수정되어야함
+     * @return
+     */
     public static MemoResponse toCheckedMemo(String message, Long memoId, IsChecked isChecked) {
         return MemoResponse.builder()
                 .message(message)
@@ -62,7 +68,15 @@ public class MemoResponse {
     }
 
 
-    // 여러/단일 메모 조회에 이용되는 메서드
+    /**
+     * 메모 목록/단건 조회시 이용
+     * @param message : 성공시 응답 메시지
+     * @param memoId : 조회된 메모 아이디
+     * @param memoContent: 조회된 메모의 내용
+     * @param isVisible : 조회된 메모가 보이는지 여부
+     * @param isChecked : 조회된 메모가 체크되었는지 여부
+     * @return : 조회된 메모를 엔티티로 가공하여 반환
+     */
     public static MemoResponse toMemo(String message, Long memoId, String memoContent, IsVisible isVisible, IsChecked isChecked) {
         return MemoResponse.builder()
                 .memoId(memoId)

--- a/mylog/src/main/java/mylog_backend/mylog/memo/MemoService.java
+++ b/mylog/src/main/java/mylog_backend/mylog/memo/MemoService.java
@@ -7,7 +7,6 @@ import mylog_backend.mylog.user.User;
 import mylog_backend.mylog.user.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,13 +21,13 @@ public class MemoService {
     /**
      * 1. 메모 생성 메서드
      * @param memoRequest : 메모 요청 DTO
-     * @return : 메모 응답 DTO
+     * @return : of()로 성공시 메시지와 저장된 메모 아이디를 반환
      */
     @Transactional
-    public MemoResponse createMemo(Long userId, @RequestBody MemoRequest memoRequest) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+    public MemoResponse createMemo(Long userId, MemoRequest memoRequest) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
 
-        Memo memo = memoRequest.from();
+        Memo memo = memoRequest.toMemo();
         user.addMemo(memo); // 연관관계 메서드
 
         Memo savedMemo =  memoRepository.save(memo);
@@ -38,7 +37,10 @@ public class MemoService {
 
 
     /**
-     * 2. 메모 체크시 숨기는 메서드
+     * 메모를 체크시 논리적 삭제가 이루어져 보이지 않음
+     * @param userId : 요청한 사용자의 아이디
+     * @param memoId : 체크 표시가 요청된 메모의 아이디
+     * @return : toCheckedMemo()로 성공 메시지와 체크 표시된 메모 아이디, 체크 여부를 반환
      */
     @Transactional
     public MemoResponse checkedMemo(Long userId, Long memoId) {
@@ -50,11 +52,13 @@ public class MemoService {
 
         // 3. 메모를 생성한 유저가 맞는지 판별
         if (!memo.getUser().getId().equals(userId)) {
-            throw new UnauthorizedException("본인의 메모만 수정할 수 있습니다.");
+            throw new UnauthorizedException("본인의 메모만 체크할 수 있습니다.");
         }
 
+        // 4. user에서 정의한 연관관계 메서드로 메모를 논리적 삭제
         user.removeMemo(memo);
-        memoRepository.save(memo); // is_checked 업데이트후 DB에 변경내용을 저장 -> 더티체킹 후 변경 내용이 있으면 flush
+        // 5.변경된 메모 저장
+//        memoRepository.save(memo); // is_checked 업데이트후 DB에 변경내용을 저장 -> 더티체킹 후 변경 내용이 있으면 flush
 
         return MemoResponse.toCheckedMemo("메모가 체크되어 제거되었습니다.", memo.getId(), memo.getIsChecked());
     }
@@ -62,8 +66,9 @@ public class MemoService {
 
     /**
      * 3. 메모 목록 조회 메서드
-     * - 삭제되지 않은 메모들만 조회
-     * @return
+     *  논리적 삭제가 되지 않은 메모들만 조회
+     * @param userId : 요청한 사용자 아이디
+     * @return : VISIBLE인 메모만 골라서 반환
      */
     @Transactional(readOnly = true)
     public List<MemoResponse> getVisibleMemos(Long userId) {
@@ -78,33 +83,43 @@ public class MemoService {
                         memo.getMemoContent(),
                         memo.getIsVisible(),
                         memo.getIsChecked()))
-                .collect(Collectors.toList());
+                .toList();
     }
 
 
     /**
      * 4. 단일 메모 조회 메서드
-     * @param memoId
-     * @return
+     * @param memoId : 사용자가 요청한 하나의 메모 아이디
+     * @param userId : 요청한 사용자 아이디
+     * @return :
      */
     @Transactional(readOnly = true)
     public MemoResponse getMemo(Long userId, Long memoId) {
+        // 1. 유효한 사용자인지 판단
         User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
 
+        // 2. 메모를 조회하여 할당
         Memo memo = memoRepository.findById(memoId)
                 .orElseThrow(()-> new IllegalArgumentException("메모를 찾을 수 없습니다."));
 
+        // 3. IsVisible이 HIDDEN이면 조회할 수 없음
         if (memo.getIsVisible() == IsVisible.HIDDEN) {
             throw new IllegalArgumentException("이전에 체크되어 조회할 수 없는 메모입니다.");
         }
 
-        return MemoResponse.builder()
-                .message("단일 메모 조회 성공")
-                .memoId(memo.getId())
-                .isVisible(memo.getIsVisible())
-                .memoContent(memo.getMemoContent())
-                .isChecked(memo.getIsChecked())
-                .build();
+        // 4. 본인이 작성한 메모만 조회 가능
+        if (!memo.getUser().getId().equals(userId)) {
+            throw new UnauthorizedException("본인의 메모만 수정할 수 있습니다.");
+        }
+
+        // 5. 모든 로직을 거쳤다면, 조회된 메모를 엔티티로 가공하여 반환
+        return MemoResponse.toMemo( // <-- toMemo 메서드 사용
+                "단일 메모 조회 성공", // 메시지 (필요에 따라 변경 가능)
+                memo.getId(),
+                memo.getMemoContent(),
+                memo.getIsVisible(),
+                memo.getIsChecked()
+        );
     }
 
 


### PR DESCRIPTION
- 엔티티에서 VARCHAR -> length로 변경
- 문서화를 위해 주석을 세부적으로 작성
- 요청 DTO에서 from() -> toMemo()로 변경
- 단일 메모 조회시 사용자 검증과 메모를 toMemo()로 가공하도록 변경

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#57 

## 📝작업 내용
- 엔티티에서 VARCHAR -> length로 변경
- 문서화를 위해 주석을 세부적으로 작성
- 요청 DTO에서 from() -> toMemo()로 변경
- 단일 메모 조회시 사용자 검증과 메모를 toMemo()로 가공하도록 변경


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
